### PR TITLE
Custom function to say that test is started

### DIFF
--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -5756,6 +5756,12 @@ RETURNS boolean AS $$
     SELECT TRUE;
 $$ LANGUAGE sql;
 
+-- _test_started ( test_name )
+CREATE OR REPLACE FUNCTION _test_started(TEXT)
+RETURNS TEXT AS $$
+    SELECT diag($1 || '()');
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION _runner( text[], text[], text[], text[], text[] )
 RETURNS SETOF TEXT AS $$
 DECLARE
@@ -5783,7 +5789,7 @@ BEGIN
         FOR i IN 1..array_upper(tests, 1) LOOP
             BEGIN
                 -- What test are we running?
-                IF verbos THEN RETURN NEXT diag(tests[i] || '()'); END IF;
+                IF verbos THEN RETURN NEXT _test_started(tests[i]); END IF;
 
                 -- Run the setup functions.
                 FOR tap IN SELECT * FROM _runem(setup, false) LOOP RETURN NEXT tap; END LOOP;


### PR DESCRIPTION
This is a patch to make pgTAP more friendly to automated tools when using xUnit style of tests.
Now it's possible to create custom notification for test name. For example:

```
CREATE OR REPLACE FUNCTION _test_started(TEXT)
RETURNS TEXT AS $$
    SELECT 'test ' || $1 || '()';
$$ LANGUAGE SQL;
```

This will show  
    test my_example_test_function_name()
instead of  
    #my_example_test_function_name()
This makes easy handling test name and differing test names from comments.
