### PR TITLE
Allow 'PG_CONFIG="/path/to/pg_config" make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAINEXT      = pgtap
 EXTENSION    = $(MAINEXT)
 EXTVERSION   = $(shell grep default_version $(MAINEXT).control | \
-               sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
+	       sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
 NUMVERSION   = $(shell echo $(EXTVERSION) | sed -e 's/\([[:digit:]]*[.][[:digit:]]*\).*/\1/')
 DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
 TESTS        = $(wildcard test/sql/*.sql)
@@ -9,9 +9,7 @@ EXTRA_CLEAN  = sql/pgtap.sql sql/uninstall_pgtap.sql sql/pgtap-core.sql sql/pgta
 DOCS         = doc/pgtap.mmd
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test --load-language=plpgsql
-ifndef PG_CONFIG
-PG_CONFIG    = pg_config
-endif
+PG_CONFIG   ?= pg_config
 
 ifdef NO_PGXS
 top_builddir = ../..
@@ -55,7 +53,7 @@ endif
 ifndef HAVE_HARNESS
     $(warning To use pg_prove, TAP::Parser::SourceHandler::pgTAP Perl module)
     $(warning must be installed from CPAN. To do so, simply run:)
-    $(warning     cpan TAP::Parser::SourceHandler::pgTAP) 
+    $(warning     cpan TAP::Parser::SourceHandler::pgTAP)
 endif
 
 # Enum tests not supported by 8.2 and earlier.


### PR DESCRIPTION
Allow `PG_CONFIG="/path/to/pg_config" make` without having to export an environment variable or use `env`.

I've developed this patch specifically for Gentoo, but might like it.
