### PR TITLE
Fixed bug in Makefile lines 54-56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ HAVE_HARNESS := $(shell $(PERL) -le 'eval { require TAP::Parser::SourceHandler::
 endif
 
 ifndef HAVE_HARNESS
-	$(warning To use pg_prove, TAP::Parser::SourceHandler::pgTAP Perl module)
-	$(warning must be installed from CPAN. To do so, simply run:)
-	$(warning     cpan TAP::Parser::SourceHandler::pgTAP)
+$(warning To use pg_prove, TAP::Parser::SourceHandler::pgTAP Perl module)
+$(warning must be installed from CPAN. To do so, simply run:)
+$(warning     cpan TAP::Parser::SourceHandler::pgTAP)
 endif
 
 # Enum tests not supported by 8.2 and earlier.


### PR DESCRIPTION
Deleted leading tab in lines 54 to 56.

I would get the following error
Makefile:54: **\* commands commence before first target.  Stop.
