### PR TITLE
Fix syntax error in documentation

### DIFF
--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -753,8 +753,8 @@ an unnecessary PITA. Each of the query-executing functions in this section
 thus support an alternative to make your tests more SQLish: using prepared
 statements.
 
-[Prepared statements](http://www.postgresql.org/docs/current/static/sql-prepare.html
-"PostgreSQL Documentation: PREPARE") allow you to just write SQL and simply
+[Prepared statements](http://www.postgresql.org/docs/current/static/sql-prepare.html)
+allow you to just write SQL and simply
 pass the prepared statement names to test functions. For example, the above
 example can be rewritten as:
 


### PR DESCRIPTION
There's an error in the markdown syntax, making the link not clickable.
