### PR TITLE
Try to escape expected output of performs_within to satisfy pre-9.1

### DIFF
--- a/test/sql/performs_within.sql
+++ b/test/sql/performs_within.sql
@@ -52,8 +52,8 @@ SELECT * FROM check_test(
     false,
     'simple select fail',
     'whatever',
-    ' average runtime: [[:digit:]]+([.][[:digit:]]+)? ms
- desired average: 0 \+/- 0 ms',
+    ' average runtime: [[:digit:]]+([.][[:digit:]]+)? ms' ||
+    E'\n' || ' desired average: 0 \+/- 0 ms',
     true
 );
 
@@ -62,8 +62,8 @@ SELECT * FROM check_test(
     false,
     'simple select no desc fail',
     'Should run within 0 +/- 0 ms',
-    ' average runtime: [[:digit:]]+([.][[:digit:]]+)? ms
- desired average: 0 \+/- 0 ms',
+    ' average runtime: [[:digit:]]+([.][[:digit:]]+)? ms' ||
+    E'\n' || ' desired average: 0 \+/- 0 ms',
     true
 );
 
@@ -72,8 +72,8 @@ SELECT * FROM check_test(
     false,
     'simple select no desc numeric fail',
     'Should run within 0.0 +/- 0.0 ms',
-    ' average runtime: [[:digit:]]+([.][[:digit:]]+)? ms
- desired average: 0.0 \+/- 0.0 ms',
+    ' average runtime: [[:digit:]]+([.][[:digit:]]+)? ms' ||
+    E'\n' || ' desired average: 0.0 \+/- 0.0 ms',
     true
 );
 


### PR DESCRIPTION
My last set of commits (#63) broke some of the CI tests under versions of PostgreSQL < 9.1.

I'm not familiar with properly escaping characters in PostgreSQL.  My diagnostic errors contain '+/-' in them, and that was throwing off some of the tests.  I think the tests must interpret the "+" to be part of a pattern match and not a literal '+'.  When I was originally working on the tests, I tried throwing a '\' in front of the '+' and that worked nicely for my version of PostgreSQL (9.3).

However, my tests also included an implicit new line character, so THAT may be the problem.  I changed my tests to explicitly escape the newline character (E'\n') and I hope that gets the tests passing under < 9.1.  I don't have easy access to earlier versions of PostgreSQL so I wasn't able to test these changes.  I also don't know how to get the CI system to test these changes without submitting them as a pull request.

I hope CI passes!
