### PR TITLE
Update _runner to live when test function dies.

### DIFF
--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -5997,10 +5997,13 @@ BEGIN
                 num_faild := num_faild + num_failed();
                 RAISE EXCEPTION '__TAP_ROLLBACK__';
 
-            EXCEPTION WHEN raise_exception THEN
+            EXCEPTION WHEN OTHERS THEN
                 IF SQLERRM <> '__TAP_ROLLBACK__' THEN
-                    -- We didn't raise it, so propagate it.
-                    RAISE EXCEPTION '%', SQLERRM;
+                    -- We didn't raise it, so return a failure.
+                    RETURN NEXT fail('Unexpected exception') || E'\n' || diag(
+                        '        died: ' || SQLSTATE || ': ' || SQLERRM
+                    );
+                    num_faild := num_faild + num_failed();
                 END IF;
             END;
         END LOOP;
@@ -6010,10 +6013,12 @@ BEGIN
 
         -- Raise an exception to rollback any changes.
         RAISE EXCEPTION '__TAP_ROLLBACK__';
-    EXCEPTION WHEN raise_exception THEN
+    EXCEPTION WHEN OTHERS THEN
         IF SQLERRM <> '__TAP_ROLLBACK__' THEN
-            -- We didn't raise it, so propagate it.
-            RAISE EXCEPTION '%', SQLERRM;
+            -- We didn't raise it, so return a failure.
+            RETURN NEXT fail('Unexpected exception') || E'\n' || diag(
+                '        died: ' || SQLSTATE || ': ' || SQLERRM
+            );
         END IF;
     END;
     -- Finish up.


### PR DESCRIPTION
- When Startup dies, runner dies.
- When some of Setup, Test, Teardown or Shutdown die, runner indicates a failure and continues.

Resolves #68 Exception in one test crushes entire suit.
