### PR TITLE
Update _runner to live when test function dies.

### DIFF
--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -5997,10 +5997,16 @@ BEGIN
                 num_faild := num_faild + num_failed();
                 RAISE EXCEPTION '__TAP_ROLLBACK__';
 
-            EXCEPTION WHEN raise_exception THEN
+            EXCEPTION WHEN OTHERS THEN
                 IF SQLERRM <> '__TAP_ROLLBACK__' THEN
-                    -- We didn't raise it, so propagate it.
-                    RAISE EXCEPTION '%', SQLERRM;
+                    -- We didn't raise it, so return a failure.
+                    RETURN NEXT fail('Unexpected exception') || E'\n' || diag(
+                        '        died: ' || SQLSTATE || ': ' || SQLERRM
+                    );
+                    num_faild := num_faild + 1;
+
+                    -- Previous fail() was not rolled back
+                    DELETE FROM __tresults__;
                 END IF;
             END;
         END LOOP;
@@ -6010,10 +6016,13 @@ BEGIN
 
         -- Raise an exception to rollback any changes.
         RAISE EXCEPTION '__TAP_ROLLBACK__';
-    EXCEPTION WHEN raise_exception THEN
+    EXCEPTION WHEN OTHERS THEN
         IF SQLERRM <> '__TAP_ROLLBACK__' THEN
-            -- We didn't raise it, so propagate it.
-            RAISE EXCEPTION '%', SQLERRM;
+            -- We didn't raise it, so return a failure.
+            RETURN NEXT fail('Unexpected exception in shutdown') || E'\n' || diag(
+                '        died: ' || SQLSTATE || ': ' || SQLERRM
+            );
+            num_faild := num_faild + 1;
         END IF;
     END;
     -- Finish up.

--- a/test/expected/runtestsexc.out
+++ b/test/expected/runtestsexc.out
@@ -1,0 +1,27 @@
+\unset ECHO
+# whatever.test1this()
+ok 1 - simple pass
+ok 2 - another simple pass
+not ok 3 - Unexpected exception
+# Failed test 3: "Unexpected exception"
+#         died: P0001: Runner should continue after exception in teardown
+# whatever.test2unexpectedexception()
+not ok 4 - Unexpected exception
+# Failed test 4: "Unexpected exception"
+#         died: P0001: Runner should continue after exception in test
+# whatever.test3plpgsql()
+ok 5 - plpgsql simple
+ok 6 - plpgsql simple 2
+ok 7 - Should be a 1 in the test table
+not ok 8 - Unexpected exception
+# Failed test 8: "Unexpected exception"
+#         died: P0001: Runner should continue after exception in teardown
+# whatever.testunexpectedexception()
+not ok 9 - Unexpected exception
+# Failed test 9: "Unexpected exception"
+#         died: P0001: Runner should continue after exception in test
+not ok 10 - Unexpected exception in shutdown
+# Failed test 10: "Unexpected exception in shutdown"
+#         died: P0001: Runner should continue after exception in shutdown
+1..10
+# Looks like you failed 5 tests of 10

--- a/test/sql/runtestsexc.sql
+++ b/test/sql/runtestsexc.sql
@@ -1,0 +1,54 @@
+\unset ECHO
+\i test/setup.sql
+SET client_min_messages = warning;
+
+CREATE SCHEMA whatever;
+CREATE TABLE whatever.foo ( id serial primary key );
+
+-- Make sure we get test function names.
+SET client_min_messages = notice;
+
+CREATE OR REPLACE FUNCTION whatever.test1this() RETURNS SETOF TEXT AS $$
+    SELECT pass('simple pass') AS foo
+    UNION SELECT pass('another simple pass')
+    ORDER BY foo ASC;
+$$ LANGUAGE SQL;
+
+-- Make sure we have tests after the test with exception
+CREATE OR REPLACE FUNCTION whatever.test2unexpectedexception() RETURNS SETOF TEXT AS $$
+BEGIN
+    RAISE EXCEPTION 'Runner should continue after exception in test';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION whatever.test3plpgsql() RETURNS SETOF TEXT AS $$
+BEGIN
+    RETURN NEXT pass( 'plpgsql simple' );
+    RETURN NEXT pass( 'plpgsql simple 2' );
+    INSERT INTO whatever.foo VALUES(1);
+    RETURN NEXT is( MAX(id), 1, 'Should be a 1 in the test table') FROM whatever.foo;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION whatever.testunexpectedexception() RETURNS SETOF TEXT AS $$
+BEGIN
+    RAISE EXCEPTION 'Runner should continue after exception in test';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION whatever.teardownunexpectedexception() RETURNS SETOF TEXT AS $$
+BEGIN
+    RAISE EXCEPTION 'Runner should continue after exception in teardown';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION whatever.shutdownunexpectedexception() RETURNS SETOF TEXT AS $$
+BEGIN
+    RAISE EXCEPTION 'Runner should continue after exception in shutdown';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Run the actual tests. Yes, it's a one-liner!
+SELECT * FROM runtests('whatever'::name);
+
+ROLLBACK;


### PR DESCRIPTION
- When Startup dies, runner dies.
- When some of Setup, Test, Teardown or Shutdown die, runner indicates a failure and continues.

Resolves #68 Exception in one test crushes entire suit.
