### PR TITLE
add extension test support

### DIFF
--- a/sql/pgtap--unpackaged--0.91.0.sql
+++ b/sql/pgtap--unpackaged--0.91.0.sql
@@ -712,3 +712,6 @@ ALTER EXTENSION pgtap ADD FUNCTION columns_are( NAME, NAME[] );
 ALTER EXTENSION pgtap ADD FUNCTION _get_db_owner( NAME );
 ALTER EXTENSION pgtap ADD FUNCTION db_owner_is ( NAME, NAME, TEXT );
 ALTER EXTENSION pgtap ADD FUNCTION db_owner_is ( NAME, NAME );
+ALTER EXTENSION pgtap ADD FUNCTION _installed_extensions( NAME );
+ALTER EXTENSION pgtap ADD FUNCTION has_extensions_installed( NAME, NAME[], TEXT );
+ALTER EXTENSION pgtap ADD FUNCTION has_extensions_installed( NAME, NAME[]);

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -9432,5 +9432,43 @@ RETURNS TEXT AS $$
     );
 $$ LANGUAGE SQL;
 
+-- get installed extensions in a given schema
+CREATE OR REPLACE FUNCTION _installed_extensions( NAME )
+RETURNS SETOF NAME AS $$
+    SELECT extname
+    FROM pg_catalog.pg_extension
+    WHERE extnamespace = $1::regnamespace
+    ORDER BY extname ASC
+$$ LANGUAGE SQL;
+
+-- has_extensions_installed( schema, extensions, description )
+CREATE OR REPLACE FUNCTION has_extensions_installed( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _are(
+        'extensions',
+        ARRAY(
+            SELECT _installed_extensions($1)
+            EXCEPT
+            SELECT unnest($2)
+        ),
+        ARRAY(
+            SELECT unnest($2)
+            EXCEPT
+            SELECT _installed_extensions($1)
+        ),
+        $3
+    );
+$$ LANGUAGE SQL;
+
+-- has_extensions_installed( schema, extensions)
+CREATE OR REPLACE FUNCTION has_extensions_installed( NAME, NAME[])
+RETURNS TEXT AS $$
+  SELECT has_extensions_installed(
+        $1,
+        $2,
+        'There should be the correct extensions installed.'
+    );
+$$ LANGUAGE SQL;
+
 GRANT SELECT ON tap_funky           TO PUBLIC;
 GRANT SELECT ON pg_all_foreign_keys TO PUBLIC;

--- a/sql/uninstall_pgtap.sql.in
+++ b/sql/uninstall_pgtap.sql.in
@@ -1,3 +1,6 @@
+DROP FUNCTION has_extensions_installed( NAME, NAME[]);
+DROP FUNCTION has_extensions_installed( NAME, NAME[], TEXT );
+DROP FUNCTION _installed_extensions( NAME );
 DROP FUNCTION server_privs_are ( NAME, NAME, NAME[] );
 DROP FUNCTION server_privs_are ( NAME, NAME, NAME[], TEXT );
 DROP FUNCTION _get_server_privs (NAME, TEXT);


### PR DESCRIPTION
Added the `has_extensions_installed` methods to specify a list of extensions we want installed (ie types and functions to exist).

I did not exclude pgtap from the list of extensions so it must be listed as needed extensions.