### PR TITLE
Throw an exception when passing true to finish()

### DIFF
--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -310,6 +310,11 @@ discrepancy between the planned number of tests and the number actually run:
 
     SELECT * FROM finish();
 
+If you need to throw an exception if some test failed, you can pass an
+option to `finish()`.
+    
+    SELECT * FROM finish(true);    
+    
 What a sweet unit!
 ------------------
 

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -185,13 +185,14 @@ RETURNS INTEGER AS $$
     SELECT _get('failed');
 $$ LANGUAGE SQL strict;
 
-CREATE OR REPLACE FUNCTION _finish (INTEGER, INTEGER, INTEGER)
+CREATE OR REPLACE FUNCTION _finish (INTEGER, INTEGER, INTEGER, BOOLEAN)
 RETURNS SETOF TEXT AS $$
 DECLARE
     curr_test ALIAS FOR $1;
     exp_tests INTEGER := $2;
     num_faild ALIAS FOR $3;
     plural    CHAR;
+    raise_ex  ALIAS FOR $4;
 BEGIN
     plural    := CASE exp_tests WHEN 1 THEN '' ELSE 's' END;
 
@@ -211,6 +212,9 @@ BEGIN
             plural || ' but ran ' || curr_test
         );
     ELSIF num_faild > 0 THEN
+        IF raise_ex THEN
+            RAISE EXCEPTION  '% test% failed of %', num_faild, CASE num_faild WHEN 1 THEN '' ELSE 's' END, exp_tests;
+        END IF;
         RETURN NEXT diag(
             'Looks like you failed ' || num_faild || ' test' ||
             CASE num_faild WHEN 1 THEN '' ELSE 's' END
@@ -223,12 +227,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION finish (BOOLEAN)
+RETURNS SETOF TEXT AS $$
+    SELECT * FROM _finish(
+        _get('curr_test'),
+        _get('plan'),
+        num_failed(),
+        $1
+    );
+$$ LANGUAGE sql;
+
 CREATE OR REPLACE FUNCTION finish ()
 RETURNS SETOF TEXT AS $$
     SELECT * FROM _finish(
         _get('curr_test'),
         _get('plan'),
-        num_failed()
+        num_failed(),
+        false
     );
 $$ LANGUAGE sql;
 
@@ -6200,7 +6215,7 @@ BEGIN
     FOR tap IN SELECT * FROM _runem(shutdown, false) LOOP RETURN NEXT tap; END LOOP;
 
     -- Finish up.
-    FOR tap IN SELECT * FROM _finish( COALESCE(_get('curr_test'), 0), 0, tfaild ) LOOP
+    FOR tap IN SELECT * FROM _finish( COALESCE(_get('curr_test'), 0), 0, tfaild, false ) LOOP
         RETURN NEXT tap;
     END LOOP;
 


### PR DESCRIPTION
Ref #80 

Retro compatibility is preserved, an exception is thrown on demand 
