### PR TITLE
Support FK tests on temp tables

### DIFF
--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -2379,9 +2379,18 @@ DECLARE
     tab  name;
     cols name[];
 BEGIN
-    SELECT pk_schema_name, pk_table_name, pk_columns
+    SELECT CASE
+            WHEN pk_schema_name = pg_my_temp_schema()::regnamespace::name
+                    AND lower($4) IN ('pg_temp', '"pg_temp"')
+                THEN $4
+            ELSE pk_schema_name
+        END,
+        pk_table_name, pk_columns
       FROM pg_all_foreign_keys
-      WHERE fk_schema_name = $1
+      WHERE fk_schema_name = CASE
+                WHEN lower($1) IN ('pg_temp', '"pg_temp"') THEN pg_my_temp_schema()::regnamespace::name
+                ELSE $1
+            END
         AND fk_table_name  = $2
         AND fk_columns     = $3
       INTO sch, tab, cols;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -2380,17 +2380,19 @@ DECLARE
     cols name[];
 BEGIN
     SELECT CASE
-            WHEN pk_schema_name = pg_my_temp_schema()::regnamespace::name
+            -- Need to special-case pg_temp since the real temp schema name is always pg_temp_<some number>
+            WHEN pk_schema_name LIKE 'pg_temp_%'
                     AND lower($4) IN ('pg_temp', '"pg_temp"')
                 THEN $4
             ELSE pk_schema_name
         END,
         pk_table_name, pk_columns
       FROM pg_all_foreign_keys
-      WHERE fk_schema_name = CASE
-                WHEN lower($1) IN ('pg_temp', '"pg_temp"') THEN pg_my_temp_schema()::regnamespace::name
-                ELSE $1
-            END
+      WHERE
+        (
+            ( lower($1) IN ('pg_temp', '"pg_temp"') AND fk_schema_name LIKE 'pg_temp_%' )
+            OR fk_schema_name = $1
+        )
         AND fk_table_name  = $2
         AND fk_columns     = $3
       INTO sch, tab, cols;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1850,16 +1850,12 @@ $$ LANGUAGE SQL immutable strict;
 -- Borrowed from newsysviews: http://pgfoundry.org/projects/newsysviews/
 CREATE OR REPLACE VIEW pg_all_foreign_keys
 AS
-  SELECT CASE WHEN n1.oid = pg_my_temp_schema() THEN 'pg_temp'::name
-              ELSE n1.nspname
-            END                                       AS fk_schema_name,
+  SELECT n1.nspname                                   AS fk_schema_name,
          c1.relname                                   AS fk_table_name,
          k1.conname                                   AS fk_constraint_name,
          c1.oid                                       AS fk_table_oid,
          _pg_sv_column_array(k1.conrelid,k1.conkey)   AS fk_columns,
-         CASE WHEN n2.oid = pg_my_temp_schema() THEN 'pg_temp'::name
-              ELSE n2.nspname
-            END                                       AS pk_schema_name,
+         n2.nspname                                   AS pk_schema_name,
          c2.relname                                   AS pk_table_name,
          k2.conname                                   AS pk_constraint_name,
          c2.oid                                       AS pk_table_oid,
@@ -2383,9 +2379,18 @@ DECLARE
     tab  name;
     cols name[];
 BEGIN
-    SELECT pk_schema_name, pk_table_name, pk_columns
+    SELECT CASE
+            WHEN pk_schema_name = pg_my_temp_schema()::regnamespace::name
+                    AND lower($4) IN ('pg_temp', '"pg_temp"')
+                THEN $4
+            ELSE pk_schema_name
+        END,
+        pk_table_name, pk_columns
       FROM pg_all_foreign_keys
-      WHERE fk_schema_name = $1
+      WHERE fk_schema_name = CASE
+                WHEN lower($1) IN ('pg_temp', '"pg_temp"') THEN pg_my_temp_schema()::regnamespace::name
+                ELSE $1
+            END
         AND fk_table_name  = $2
         AND fk_columns     = $3
       INTO sch, tab, cols;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1850,12 +1850,16 @@ $$ LANGUAGE SQL immutable strict;
 -- Borrowed from newsysviews: http://pgfoundry.org/projects/newsysviews/
 CREATE OR REPLACE VIEW pg_all_foreign_keys
 AS
-  SELECT n1.nspname                                   AS fk_schema_name,
+  SELECT CASE WHEN n1.oid = pg_my_temp_schema() THEN 'pg_temp'::name
+              ELSE n1.nspname
+            END                                       AS fk_schema_name,
          c1.relname                                   AS fk_table_name,
          k1.conname                                   AS fk_constraint_name,
          c1.oid                                       AS fk_table_oid,
          _pg_sv_column_array(k1.conrelid,k1.conkey)   AS fk_columns,
-         n2.nspname                                   AS pk_schema_name,
+         CASE WHEN n2.oid = pg_my_temp_schema() THEN 'pg_temp'::name
+              ELSE n2.nspname
+            END                                       AS pk_schema_name,
          c2.relname                                   AS pk_table_name,
          k2.conname                                   AS pk_constraint_name,
          c2.oid                                       AS pk_table_oid,
@@ -2379,18 +2383,9 @@ DECLARE
     tab  name;
     cols name[];
 BEGIN
-    SELECT CASE
-            WHEN pk_schema_name = pg_my_temp_schema()::regnamespace::name
-                    AND lower($4) IN ('pg_temp', '"pg_temp"')
-                THEN $4
-            ELSE pk_schema_name
-        END,
-        pk_table_name, pk_columns
+    SELECT pk_schema_name, pk_table_name, pk_columns
       FROM pg_all_foreign_keys
-      WHERE fk_schema_name = CASE
-                WHEN lower($1) IN ('pg_temp', '"pg_temp"') THEN pg_my_temp_schema()::regnamespace::name
-                ELSE $1
-            END
+      WHERE fk_schema_name = $1
         AND fk_table_name  = $2
         AND fk_columns     = $3
       INTO sch, tab, cols;

--- a/test/expected/fktap.out
+++ b/test/expected/fktap.out
@@ -78,53 +78,58 @@ ok 75 - col_isnt_fk( table, column[] ) should fail
 ok 76 - col_isnt_fk( table, column[] ) should have the proper description
 ok 77 - full fk_ok array should pass
 ok 78 - full fk_ok array should have the proper description
-ok 79 - multiple fk fk_ok desc should pass
-ok 80 - multiple fk fk_ok desc should have the proper description
-ok 81 - fk_ok array desc should pass
-ok 82 - fk_ok array desc should have the proper description
-ok 83 - fk_ok array noschema desc should pass
-ok 84 - fk_ok array noschema desc should have the proper description
-ok 85 - multiple fk fk_ok noschema desc should pass
-ok 86 - multiple fk fk_ok noschema desc should have the proper description
-ok 87 - fk_ok array noschema should pass
-ok 88 - fk_ok array noschema should have the proper description
-ok 89 - basic fk_ok should pass
-ok 90 - basic fk_ok should have the proper description
-ok 91 - basic fk_ok desc should pass
-ok 92 - basic fk_ok desc should have the proper description
-ok 93 - basic fk_ok noschema should pass
-ok 94 - basic fk_ok noschema should have the proper description
-ok 95 - basic fk_ok noschema desc should pass
-ok 96 - basic fk_ok noschema desc should have the proper description
-ok 97 - basic fk_ok noschema desc should have the proper diagnostics
-ok 98 - Test should pass
-ok 99 - fk_ok fail should fail
-ok 100 - fk_ok fail should have the proper description
-ok 101 - fk_ok fail should have the proper diagnostics
-ok 102 - fk_ok fail desc should fail
-ok 103 - fk_ok fail desc should have the proper description
-ok 104 - fk_ok fail desc should have the proper diagnostics
-ok 105 - fk_ok fail no schema should fail
-ok 106 - fk_ok fail no schema should have the proper description
-ok 107 - fk_ok fail no schema should have the proper diagnostics
-ok 108 - fk_ok fail no schema desc should fail
-ok 109 - fk_ok fail no schema desc should have the proper description
-ok 110 - fk_ok fail no schema desc should have the proper diagnostics
-ok 111 - fk_ok bad PK test should fail
-ok 112 - fk_ok bad PK test should have the proper description
-ok 113 - fk_ok bad PK test should have the proper diagnostics
-ok 114 - double fk schema test should pass
-ok 115 - double fk schema test should have the proper description
-ok 116 - double fk schema test should have the proper diagnostics
-ok 117 - double fk test should pass
-ok 118 - double fk test should have the proper description
-ok 119 - double fk test should have the proper diagnostics
-ok 120 - double fk and col schema test should pass
-ok 121 - double fk and col schema test should have the proper description
-ok 122 - double fk and col schema test should have the proper diagnostics
-ok 123 - missing fk test should fail
-ok 124 - missing fk test should have the proper description
-ok 125 - missing fk test should have the proper diagnostics
-ok 126 - bad FK column test should fail
-ok 127 - bad FK column test should have the proper description
-ok 128 - bad FK column test should have the proper diagnostics
+ok 79 - pg_temp should pass
+ok 80 - pg_temp should have the proper description
+ok 81 - pg_my_temp_schema() should pass
+ok 82 - pg_my_temp_schema() should have the proper description
+ok 83 - multiple fk fk_ok desc should pass
+ok 84 - multiple fk fk_ok desc should have the proper description
+ok 85 - fk_ok array desc should pass
+ok 86 - fk_ok array desc should have the proper description
+ok 87 - fk_ok array noschema desc should pass
+ok 88 - fk_ok array noschema desc should have the proper description
+ok 89 - multiple fk fk_ok noschema desc should pass
+ok 90 - multiple fk fk_ok noschema desc should have the proper description
+ok 91 - fk_ok array noschema should pass
+ok 92 - fk_ok array noschema should have the proper description
+ok 93 - basic fk_ok should pass
+ok 94 - basic fk_ok should have the proper description
+ok 95 - basic fk_ok desc should pass
+ok 96 - basic fk_ok desc should have the proper description
+ok 97 - basic fk_ok noschema should pass
+ok 98 - basic fk_ok noschema should have the proper description
+ok 99 - basic fk_ok noschema desc should pass
+ok 100 - basic fk_ok noschema desc should have the proper description
+ok 101 - basic fk_ok noschema desc should have the proper diagnostics
+ok 102 - Test should pass
+ok 103 - fk_ok fail should fail
+ok 104 - fk_ok fail should have the proper description
+ok 105 - fk_ok fail should have the proper diagnostics
+ok 106 - fk_ok fail desc should fail
+ok 107 - fk_ok fail desc should have the proper description
+ok 108 - fk_ok fail desc should have the proper diagnostics
+ok 109 - fk_ok fail no schema should fail
+ok 110 - fk_ok fail no schema should have the proper description
+ok 111 - fk_ok fail no schema should have the proper diagnostics
+ok 112 - fk_ok fail no schema desc should fail
+ok 113 - fk_ok fail no schema desc should have the proper description
+ok 114 - fk_ok fail no schema desc should have the proper diagnostics
+ok 115 - fk_ok bad PK test should fail
+ok 116 - fk_ok bad PK test should have the proper description
+ok 117 - fk_ok bad PK test should have the proper diagnostics
+ok 118 - double fk schema test should pass
+ok 119 - double fk schema test should have the proper description
+ok 120 - double fk schema test should have the proper diagnostics
+ok 121 - double fk test should pass
+ok 122 - double fk test should have the proper description
+ok 123 - double fk test should have the proper diagnostics
+ok 124 - double fk and col schema test should pass
+ok 125 - double fk and col schema test should have the proper description
+ok 126 - double fk and col schema test should have the proper diagnostics
+ok 127 - missing fk test should fail
+ok 128 - missing fk test should have the proper description
+ok 129 - missing fk test should have the proper diagnostics
+ok 130 - bad FK column test should fail
+ok 131 - bad FK column test should have the proper description
+ok 132 - bad FK column test should have the proper diagnostics
+# Looks like you planned 128 tests but ran 132

--- a/test/sql/fktap.sql
+++ b/test/sql/fktap.sql
@@ -6,6 +6,16 @@ SELECT plan(128);
 
 -- These will be rolled back. :-)
 SET client_min_messages = warning;
+CREATE TEMP TABLE temp_pk(
+    id    INT NOT NULL PRIMARY KEY,
+    name  TEXT DEFAULT ''
+);
+
+CREATE TEMP TABLE temp_fk (
+    id    INT NOT NULL PRIMARY KEY,
+    pk_id INT NOT NULL REFERENCES temp_pk(id)
+);
+
 CREATE TABLE public.pk (
     id    INT NOT NULL PRIMARY KEY,
     name  TEXT DEFAULT ''
@@ -304,6 +314,24 @@ SELECT * FROM check_test(
     fk_ok( 'public', 'fk', ARRAY['pk_id'], 'public', 'pk', ARRAY['id'], 'WHATEVER' ),
     true,
     'full fk_ok array',
+    'WHATEVER'
+);
+
+SELECT * FROM check_test(
+    fk_ok( 'pg_temp', 'temp_fk', ARRAY['pk_id'], 'pg_temp', 'temp_pk', ARRAY['id'], 'WHATEVER' ),
+    true,
+    'pg_temp',
+    'WHATEVER'
+);
+
+SELECT * FROM check_test(
+    fk_ok(
+        pg_my_temp_schema()::regnamespace::name, 'temp_fk', ARRAY['pk_id'],
+        pg_my_temp_schema()::regnamespace::name, 'temp_pk', ARRAY['id'],
+        'WHATEVER'
+    ),
+    true,
+    'pg_my_temp_schema()',
     'WHATEVER'
 );
 

--- a/test/sql/fktap.sql
+++ b/test/sql/fktap.sql
@@ -326,8 +326,8 @@ SELECT * FROM check_test(
 
 SELECT * FROM check_test(
     fk_ok(
-        (SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema()), 'temp_fk', ARRAY['pk_id'],
-        (SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema()), 'temp_pk', ARRAY['id'],
+        pg_my_temp_schema()::regnamespace::name, 'temp_fk', ARRAY['pk_id'],
+        pg_my_temp_schema()::regnamespace::name, 'temp_pk', ARRAY['id'],
         'WHATEVER'
     ),
     true,

--- a/test/sql/fktap.sql
+++ b/test/sql/fktap.sql
@@ -326,8 +326,8 @@ SELECT * FROM check_test(
 
 SELECT * FROM check_test(
     fk_ok(
-        pg_my_temp_schema()::regnamespace::name, 'temp_fk', ARRAY['pk_id'],
-        pg_my_temp_schema()::regnamespace::name, 'temp_pk', ARRAY['id'],
+        (SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema()), 'temp_fk', ARRAY['pk_id'],
+        (SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema()), 'temp_pk', ARRAY['id'],
         'WHATEVER'
     ),
     true,


### PR DESCRIPTION
If you're testing code that deals with table structure you might need to create temporary objects, and the easiest way to do that is to put them in pg_temp. The existing fk_ok() failed in that case because it only recognized the numbered temp schema (ie: pg_temp_2).

This adds special support for when the user specifies pg_temp as one of the schemas.

BTW, you might want to merge this as a squash commit.
