### PR TITLE
Properly handle plpgsql ASSERT;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ endif
 
 sql/pgtap.sql: sql/pgtap.sql.in test/setup.sql
 	cp $< $@
+ifeq ($(shell echo $(VERSION) | grep -qE "9[.][01234]|8[.][1234]" && echo yes || echo no),yes)
+	patch -p0 < compat/install-9.4.patch
+endif
 ifeq ($(shell echo $(VERSION) | grep -qE "9[.][012]|8[.][1234]" && echo yes || echo no),yes)
 	patch -p0 < compat/install-9.2.patch
 endif

--- a/compat/install-9.4.patch
+++ b/compat/install-9.4.patch
@@ -1,0 +1,20 @@
+--- sql/pgtap.sql
++++ sql/pgtap.sql
+@@ -675,7 +675,7 @@
+            '      caught: no exception' ||
+         E'\n      wanted: ' || COALESCE( errcode, 'an exception' )
+     );
+-EXCEPTION WHEN OTHERS OR ASSERT_FAILURE THEN
++EXCEPTION WHEN OTHERS THEN
+     IF (errcode IS NULL OR SQLSTATE = errcode)
+         AND ( errmsg IS NULL OR SQLERRM = errmsg)
+     THEN
+@@ -779,7 +779,7 @@
+ BEGIN
+     EXECUTE code;
+     RETURN ok( TRUE, descr );
+-EXCEPTION WHEN OTHERS OR ASSERT_FAILURE THEN
++EXCEPTION WHEN OTHERS THEN
+     -- There should have been no exception.
+     GET STACKED DIAGNOSTICS
+         detail  = PG_EXCEPTION_DETAIL,

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -7683,10 +7683,15 @@ instead:
 To see the specifics for each version of PostgreSQL, consult the files in the
 `compat/` directory in the pgTAP distribution.
 
-9.3 and Up
+9.5 and Up
 ----------
 
 No changes. Everything should just work.
+
+9.4 and Down
+------------
+* lives_ok() and throws_ok() will not trap ASSERT_FAILURE, since asserts do not
+  exist prior to 9.5.
 
 9.2 and Down
 ------------

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -675,7 +675,7 @@ BEGIN
            '      caught: no exception' ||
         E'\n      wanted: ' || COALESCE( errcode, 'an exception' )
     );
-EXCEPTION WHEN OTHERS THEN
+EXCEPTION WHEN OTHERS OR ASSERT_FAILURE THEN
     IF (errcode IS NULL OR SQLSTATE = errcode)
         AND ( errmsg IS NULL OR SQLERRM = errmsg)
     THEN
@@ -779,7 +779,7 @@ DECLARE
 BEGIN
     EXECUTE code;
     RETURN ok( TRUE, descr );
-EXCEPTION WHEN OTHERS THEN
+EXCEPTION WHEN OTHERS OR ASSERT_FAILURE THEN
     -- There should have been no exception.
     GET STACKED DIAGNOSTICS
         detail  = PG_EXCEPTION_DETAIL,

--- a/test/expected/throwtap.out
+++ b/test/expected/throwtap.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..84
+1..97
 ok 1 - four-argument form should pass
 ok 2 - four-argument form should have the proper description
 ok 3 - four-argument form should have the proper diagnostics
@@ -84,3 +84,16 @@ ok 81 - throws_imatching(sql, regex, desc) should have the proper diagnostics
 ok 82 - throws_imatching(valid sql, regex, desc) should fail
 ok 83 - throws_imatching(valid sql, regex, desc) should have the proper description
 ok 84 - throws_imatching(valid sql, regex, desc) should have the proper diagnostics
+ok 85 - Create check_assert function
+ok 86 - throws_ok catches assert should pass
+ok 87 - throws_ok catches assert should have the proper description
+ok 88 - throws_ok catches assert should have the proper diagnostics
+ok 89 - throws_ok does not accept passing assert should fail
+ok 90 - throws_ok does not accept passing assert should have the proper description
+ok 91 - throws_ok does not accept passing assert should have the proper diagnostics
+ok 92 - lives_ok calling check_assert(true) should pass
+ok 93 - lives_ok calling check_assert(true) should have the proper description
+ok 94 - lives_ok calling check_assert(true) should have the proper diagnostics
+ok 95 - lives_ok with check_assert(false) should fail
+ok 96 - lives_ok with check_assert(false) should have the proper description
+ok 97 - lives_ok with check_assert(false) should have the proper diagnostics


### PR DESCRIPTION
lives_ok() and throws_ok() need to explicitly trap ASSERT_FAILURE in an EXCEPTION block, because it's not included as part of OTHERS.

Replacement for #116