### PR TITLE
updatecheck demo - DO NOT COMMIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,19 @@
+# THERE IS ANOTHER .gitignore IN test/sql!
+
 .*.swp
 pgtap.sql
 pgtap-core.sql
 pgtap-schema.sql
 uninstall_pgtap.sql
-test/setup.sql
 results
 pgtap.so
 regression.*
 *.html
 bbin
+
 /sql/pgtap--?.??.?.sql
 /sql/pgtap-core--*
 /sql/pgtap-schema--*
 *.sql.orig
+
+test/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: c
 before_install:
   - wget https://gist.githubusercontent.com/petere/5893799/raw/apt.postgresql.org.sh
-  - wget https://gist.githubusercontent.com/petere/6023944/raw/pg-travis-test.sh
   - sudo sh ./apt.postgresql.org.sh
   - sudo rm -vf /etc/apt/sources.list.d/pgdg-source.list
+script:
+  - bash ./pg-travis-test.sh
 env:
   - PGVERSION=9.0
   - PGVERSION=9.1
@@ -11,4 +12,5 @@ env:
   - PGVERSION=9.3
   - PGVERSION=9.4
   - PGVERSION=9.5
-script: bash ./pg-travis-test.sh
+
+# vi: expandtab ts=2 sw=2

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ REGRESS_CONF ?=
 PARALLEL_CONN ?=
 
 # This controls what version to upgrade FROM when running updatecheck.
-UPDATE_FROM ?= 0.94.0
+UPDATE_FROM ?= 0.95.0
 
 # These are test files that need to end up in test/sql to make pg_regress
 # happy, but these should NOT be treated as regular regression tests
@@ -313,7 +313,7 @@ updatecheck_setup: updatecheck_deps
 	@echo
 
 .PHONY: updatecheck_run
-updatecheck_run: updatecheck_setup install installcheck
+updatecheck_run: updatecheck_setup installcheck
 
 #
 # STOLEN FROM pgxntool

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,47 @@ EXTVERSION   = $(shell grep default_version $(MAINEXT).control | \
 			   sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
 NUMVERSION   = $(shell echo $(EXTVERSION) | sed -e 's/\([[:digit:]]*[.][[:digit:]]*\).*/\1/')
 DATA         = $(wildcard sql/*--*.sql)
-TESTS        = $(wildcard test/sql/*.sql)
 EXTRA_CLEAN  = sql/pgtap.sql sql/uninstall_pgtap.sql sql/pgtap-core.sql sql/pgtap-schema.sql doc/*.html
 DOCS         = doc/pgtap.mmd
-REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --inputdir=test --load-language=plpgsql
 PG_CONFIG   ?= pg_config
+
+#
+# Test configuration. This must be done BEFORE including PGXS
+#
+
+# If you need to, you can manually pass options to pg_regress with this variable
+REGRESS_CONF ?=
+
+# Set this to 1 to force serial test execution; otherwise it will be determined from Postgres max_connections
+PARALLEL_CONN ?=
+
+# This controls what version to upgrade FROM when running updatecheck.
+UPDATE_FROM ?= 0.94.0
+
+# These are test files that need to end up in test/sql to make pg_regress
+# happy, but these should NOT be treated as regular regression tests
+SCHEDULE_TEST_FILES = $(wildcard test/schedule/*.sql)
+SCHEDULE_DEST_FILES = $(subst test/schedule,test/sql,$(SCHEDULE_TEST_FILES))
+EXTRA_CLEAN += $(SCHEDULE_DEST_FILES)
+
+# The actual schedule files. Note that we'll build 2 additional files
+SCHEDULE_FILES = $(wildcard test/schedule/*.sch)
+
+# These are our actual regression tests
+TEST_FILES 	= $(filter-out $(SCHEDULE_DEST_FILES),$(wildcard test/sql/*.sql))
+
+# Plain test names
+TESTS		= $(notdir $(TEST_FILES:.sql=))
+
+# Some tests fail when run in parallel
+SERIAL_TESTS = coltap hastap
+PARALLEL_TESTS = $(filter-out $(SERIAL_TESTS),$(TESTS))
+
+# This is a bit of a hack, but if REGRESS isn't set we can't installcheck, and
+# it must be set BEFORE including pgxs. Note this gets set again below
+REGRESS = --schedule $(TB_DIR)/run.sch
+
+# REMAINING TEST VARIABLES ARE DEFINED IN THE TEST SECTION
 
 ifdef NO_PGXS
 top_builddir = ../..
@@ -19,7 +54,7 @@ else
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 endif
 
-# We need to do various things with the PostgreSQLl version.
+# We need to do various things with the PostgreSQL version.
 VERSION = $(shell $(PG_CONFIG) --version | awk '{print $$2}')
 
 # We support 8.1 and later.
@@ -40,6 +75,24 @@ else
 include $(PGXS)
 endif
 
+# NOTE! This currently MUST be after PGXS! The problem is that
+# $(DESTDIR)$(datadir) aren't being expanded.
+EXTENSION_DIR = $(DESTDIR)$(datadir)/extension
+extension_control = $(shell file="$(EXTENSION_DIR)/$1.control"; [ -e "$$file" ] && echo "$$file")
+ifeq (,$(call extension_control,citext))
+MISSING_EXTENSIONS += citext
+endif
+ifeq (,$(call extension_control,isn))
+MISSING_EXTENSIONS += isn
+endif
+ifeq (,$(call extension_control,ltree))
+MISSING_EXTENSIONS += ltree
+endif
+ifneq (,$(MISSING_EXTENSIONS))
+EXCLUDE_TEST_FILES += test/sql/extension.sql
+IGNORE_TESTS = $(notdir $(EXCLUDE_TEST_FILES:.sql=))
+endif
+
 # We need Perl.
 ifneq (,$(findstring missing,$(PERL)))
 PERL := $(shell which perl)
@@ -58,18 +111,6 @@ ifndef HAVE_HARNESS
 $(warning To use pg_prove, TAP::Parser::SourceHandler::pgTAP Perl module)
 $(warning must be installed from CPAN. To do so, simply run:)
 $(warning     cpan TAP::Parser::SourceHandler::pgTAP)
-endif
-
-# Enum tests not supported by 8.2 and earlier.
-ifeq ($(shell echo $(VERSION) | grep -qE "8[.][12]" && echo yes || echo no),yes)
-TESTS   := $(filter-out test/sql/enumtap.sql,$(TESTS))
-REGRESS := $(filter-out enumtap,$(REGRESS))
-endif
-
-# Values tests not supported by 8.1 and earlier.
-ifeq ($(shell echo $(VERSION) | grep -qE "8[.][1]" && echo yes || echo no),yes)
-TESTS   := $(filter-out test/sql/enumtap.sql sql/valueset.sql,$(TESTS))
-REGRESS := $(filter-out enumtap valueset,$(REGRESS))
 endif
 
 # Determine the OS. Borrowed from Perl's Configure.
@@ -95,7 +136,7 @@ DATA = $(wildcard sql/*--*.sql)
 EXTRA_CLEAN += sql/$(MAINEXT)--$(EXTVERSION).sql sql/$(MAINEXT)-core--$(EXTVERSION).sql sql/$(MAINEXT)-schema--$(EXTVERSION).sql
 endif
 
-sql/pgtap.sql: sql/pgtap.sql.in test/setup.sql
+sql/pgtap.sql: sql/pgtap.sql.in
 	cp $< $@
 ifeq ($(shell echo $(VERSION) | grep -qE "9[.][012]|8[.][1234]" && echo yes || echo no),yes)
 	patch -p0 < compat/install-9.2.patch
@@ -121,7 +162,7 @@ endif
 	sed -e 's,MODULE_PATHNAME,$$libdir/pgtap,g' -e 's,__OS__,$(OSNAME),g' -e 's,__VERSION__,$(NUMVERSION),g' sql/pgtap.sql > sql/pgtap.tmp
 	mv sql/pgtap.tmp sql/pgtap.sql
 
-sql/uninstall_pgtap.sql: sql/pgtap.sql test/setup.sql
+sql/uninstall_pgtap.sql: sql/pgtap.sql
 	grep '^CREATE ' sql/pgtap.sql | $(PERL) -e 'for (reverse <STDIN>) { chomp; s/CREATE (OR REPLACE)?/DROP/; print "$$_;\n" }' > sql/uninstall_pgtap.sql
 
 sql/pgtap-core.sql: sql/pgtap.sql.in
@@ -143,14 +184,142 @@ sql/pgtap-schema.sql: sql/pgtap.sql.in
 	$(PERL) compat/gencore 1 sql/pgtap-schema.tmp > sql/pgtap-schema.sql
 	rm sql/pgtap-schema.tmp
 
-# Make sure that we build the regression tests.
-installcheck: test/setup.sql
-
-# In addition to installcheck, one can also run the tests through pg_prove.
-test: test/setup.sql
-	pg_prove --pset tuples_only=1 $(TESTS)
-
 html:
 	multimarkdown doc/pgtap.mmd > doc/pgtap.html
 	./tocgen doc/pgtap.html 2> doc/toc.html
 	perl -MPod::Simple::XHTML -E "my \$$p = Pod::Simple::XHTML->new; \$$p->html_header_tags('<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">'); \$$p->strip_verbatim_indent(sub { my \$$l = shift; (my \$$i = \$$l->[0]) =~ s/\\S.*//; \$$i }); \$$p->parse_from_file('`perldoc -l pg_prove`')" > doc/pg_prove.html
+
+#
+# Actual test targets
+#
+
+# Run installcheck then output any diffs
+.PHONY: regress
+regress: installcheck_deps
+	make installcheck || ([ -e regression.diffs ] && $${PAGER:-cat} regression.diffs; exit 1)
+
+.PHONY: installcheck_deps
+installcheck_deps: $(SCHEDULE_DEST_FILES) extension_check set_parallel_conn # More dependencies below
+
+# In addition to installcheck, one can also run the tests through pg_prove.
+test: extension_check
+	pg_prove --pset tuples_only=1 $(TEST_FILES)
+
+#
+# General test support
+#
+TB_DIR = test/build
+GENERATED_SCHEDULE_DEPS = $(TB_DIR)/tests $(TB_DIR)/exclude_tests
+REGRESS = --schedule $(TB_DIR)/run.sch # Set this again just to be safe
+REGRESS_OPTS = --inputdir=test --load-language=plpgsql --max-connections=$(PARALLEL_CONN) --schedule $(SETUP_SCH) $(REGRESS_CONF)
+SETUP_SCH = test/schedule/main.sch # schedule to use for test setup; this can be forcibly changed by some targets!
+installcheck: $(TB_DIR)/run.sch
+
+# Parallel tests will use a connection for each $(PARALLEL_TESTS) if we let it,
+# but max_connections may not be set that high. You can set this manually to 1
+# for no parallelism
+#
+# This can be a bit expensive if we're not testing, so set it up as a
+# dependency of installcheck
+.PHONY: set_parallel_conn
+set_parallel_conn:
+	$(eval PARALLEL_CONN = $(shell tools/parallel_conn.sh $(PARALLEL_CONN)))
+	@[ -n "$(PARALLEL_CONN)" ]
+	@echo "Using $(PARALLEL_CONN) parallel test connections"
+
+# Have to do this as a separate task to ensure the @[ -n ... ] test in set_parallel_conn actually runs
+$(TB_DIR)/which_schedule: $(TB_DIR)/ set_parallel_conn
+	$(eval SCHEDULE = $(shell [ $(PARALLEL_CONN) -gt 1 ] && echo $(TB_DIR)/parallel.sch || echo $(TB_DIR)/serial.sch))
+	@[ -n "$(SCHEDULE)" ]
+	@[ "`cat $@ 2>/dev/null`" = "$(SCHEDULE)" ] || (echo "Schedule changed to $(SCHEDULE)"; echo "$(SCHEDULE)" > $@)
+
+# Generated schedule files, one for serial one for parallel
+.PHONY: $(TB_DIR)/tests # Need this target to force schedule rebuild if $(TEST) changes
+$(TB_DIR)/tests: $(TB_DIR)/
+	@[ "`cat $@ 2>/dev/null`" = "$(TEST)" ] || (echo "Rebuilding $@"; echo "$(TEST)" > $@)
+
+.PHONY: $(TB_DIR)/exclude_tests # Need this target to force schedule rebuild if $(EXCLUDE_TEST) changes
+$(TB_DIR)/exclude_tests: $(TB_DIR)/
+	@[ "`cat $@ 2>/dev/null`" = "$(EXCLUDE_TEST)" ] || (echo "Rebuilding $@"; echo "$(EXCLUDE_TEST)" > $@)
+
+GENERATED_SCHEDULES = $(TB_DIR)/serial.sch $(TB_DIR)/parallel.sch
+$(TB_DIR)/serial.sch: $(GENERATED_SCHEDULE_DEPS)
+	@(for f in $(IGNORE_TESTS); do echo "ignore: $$f"; done; for f in $(TESTS); do echo "test: $$f"; done) > $@
+
+$(TB_DIR)/parallel.sch: $(GENERATED_SCHEDULE_DEPS)
+	@( \
+		for f in $(SERIAL_TESTS); do echo "test: $$f"; done; \
+		([ -z "$(IGNORE_TESTS)" ] || echo "ignore: $(IGNORE_TESTS)"); \
+		([ -z "$(PARALLEL_TESTS)" ] || echo "test: $(PARALLEL_TESTS)") \
+	) > $@
+
+$(TB_DIR)/run.sch: $(TB_DIR)/which_schedule $(GENERATED_SCHEDULES)
+	cp `cat $<` $@
+
+# Don't generate noise if we're not running tests...
+.PHONY: extension_check
+extension_check:
+	@[ -z "$(MISSING_EXTENSIONS)" ] || (echo; echo; echo "WARNING: Some mandatory extensions ($(MISSING_EXTENSIONS)) are not installed; ignoring tests: $(IGNORE_TESTS)"; echo; echo)
+
+
+# These tests have specific dependencies
+test/sql/build.sql: sql/pgtap.sql
+test/sql/create.sql test/sql/update.sql: pgtap-version-$(EXTVERSION)
+
+test/sql/%.sql: test/schedule/%.sql
+	@(echo '\unset ECHO'; echo '-- GENERATED FILE! DO NOT EDIT!'; echo "-- Original file: $<"; cat $< ) > $@
+
+EXTRA_CLEAN += $(TB_DIR)/
+$(TB_DIR)/:
+	@mkdir -p $@
+
+
+#
+# Update test support
+#
+
+# If the specified version of pgtap doesn't exist, install it
+pgtap-version-%: $(EXTENSION_DIR)/pgtap--%.sql
+	@true # Necessary to have a fake action here
+
+
+$(EXTENSION_DIR)/pgtap--$(EXTVERSION).sql: install
+
+# Need to explicitly exclude the current version. I wonder if there's a way to do this with % in the target?
+# Note that we need to capture the test failure so the rule doesn't abort
+$(EXTENSION_DIR)/pgtap--%.sql:
+	@ver=$(@:$(EXTENSION_DIR)/pgtap--%.sql=%); [ "$$ver" = "$(EXTVERSION)" ] || (echo Installing pgtap version $$ver from pgxn; pgxn install pgtap=$$ver)
+
+# We do this as a separate step to change SETUP_SCH before the main updatecheck
+# recipe calls installcheck (which depends on SETUP_SCH being set correctly).
+.PHONY: updatecheck_setup
+# we dpend on pg_regress --launcher, which was added in 9.1
+updatecheck_setup: pgtap-version-$(UPDATE_FROM) test/sql/update.sql
+	@if echo $(VERSION) | grep -qE "8[.]|9[.][0]"; then echo "updatecheck is not supported prior to 9.1"; exit 1; fi
+	$(eval SETUP_SCH = test/schedule/update.sch)
+	$(eval REGRESS_OPTS += --auncher "tools/psql_args.sh -v 'old_ver=$(UPDATE_FROM)' -v 'new_ver=$(EXTVERSION)'")
+	@echo
+	@echo "###################"
+	@echo "Testing upgrade from $(UPDATE_FROM) to $(EXTVERSION)"
+	@echo "###################"
+	@echo
+
+.PHONY: updatecheck
+updatecheck: updatecheck_setup install regress
+
+#
+# STOLEN FROM pgxntool
+#
+
+# make results: runs `make test` and copy all result files to expected
+# DO NOT RUN THIS UNLESS YOU'RE CERTAIN ALL YOUR TESTS ARE PASSING!
+.PHONY: results
+results: installcheck result-rsync
+
+.PHONY:
+result-rsync:
+	rsync -rlpgovP results/ test/expected
+
+
+# To use this, do make print-VARIABLE_NAME
+print-%	: ; $(info $* is $(flavor $*) variable set to "$($*)") @true

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,11 @@ html:
 # Run installcheck then output any diffs
 .PHONY: regress
 regress: installcheck_deps
-	make installcheck || ([ -e regression.diffs ] && $${PAGER:-cat} regression.diffs; exit 1)
+	$(MAKE) installcheck || ([ -e regression.diffs ] && $${PAGER:-cat} regression.diffs; exit 1)
+
+.PHONY: updatecheck
+updatecheck: updatecheck_deps install
+	$(MAKE) updatecheck_run || ([ -e regression.diffs ] && $${PAGER:-cat} regression.diffs; exit 1)
 
 .PHONY: installcheck_deps
 installcheck_deps: $(SCHEDULE_DEST_FILES) extension_check set_parallel_conn # More dependencies below
@@ -213,7 +217,7 @@ GENERATED_SCHEDULE_DEPS = $(TB_DIR)/tests $(TB_DIR)/exclude_tests
 REGRESS = --schedule $(TB_DIR)/run.sch # Set this again just to be safe
 REGRESS_OPTS = --inputdir=test --load-language=plpgsql --max-connections=$(PARALLEL_CONN) --schedule $(SETUP_SCH) $(REGRESS_CONF)
 SETUP_SCH = test/schedule/main.sch # schedule to use for test setup; this can be forcibly changed by some targets!
-installcheck: $(TB_DIR)/run.sch
+installcheck: $(TB_DIR)/run.sch installcheck_deps
 
 # Parallel tests will use a connection for each $(PARALLEL_TESTS) if we let it,
 # but max_connections may not be set that high. You can set this manually to 1
@@ -290,22 +294,26 @@ $(EXTENSION_DIR)/pgtap--$(EXTVERSION).sql: install
 $(EXTENSION_DIR)/pgtap--%.sql:
 	@ver=$(@:$(EXTENSION_DIR)/pgtap--%.sql=%); [ "$$ver" = "$(EXTVERSION)" ] || (echo Installing pgtap version $$ver from pgxn; pgxn install pgtap=$$ver)
 
+# This is separated out so it can be called before calling updatecheck_run
+.PHONY: updatecheck_deps
+updatecheck_deps: pgtap-version-$(UPDATE_FROM) test/sql/update.sql
+
 # We do this as a separate step to change SETUP_SCH before the main updatecheck
 # recipe calls installcheck (which depends on SETUP_SCH being set correctly).
 .PHONY: updatecheck_setup
 # we dpend on pg_regress --launcher, which was added in 9.1
-updatecheck_setup: pgtap-version-$(UPDATE_FROM) test/sql/update.sql
+updatecheck_setup: updatecheck_deps
 	@if echo $(VERSION) | grep -qE "8[.]|9[.][0]"; then echo "updatecheck is not supported prior to 9.1"; exit 1; fi
 	$(eval SETUP_SCH = test/schedule/update.sch)
-	$(eval REGRESS_OPTS += --auncher "tools/psql_args.sh -v 'old_ver=$(UPDATE_FROM)' -v 'new_ver=$(EXTVERSION)'")
+	$(eval REGRESS_OPTS += --launcher "tools/psql_args.sh -v 'old_ver=$(UPDATE_FROM)' -v 'new_ver=$(EXTVERSION)'")
 	@echo
 	@echo "###################"
 	@echo "Testing upgrade from $(UPDATE_FROM) to $(EXTVERSION)"
 	@echo "###################"
 	@echo
 
-.PHONY: updatecheck
-updatecheck: updatecheck_setup install regress
+.PHONY: updatecheck_run
+updatecheck_run: updatecheck_setup install installcheck
 
 #
 # STOLEN FROM pgxntool

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Based on https://gist.github.com/petere/6023944
+
+set -eux
+
+sudo apt-get update
+
+packages="python-setuptools postgresql-$PGVERSION postgresql-server-dev-$PGVERSION postgresql-common"
+
+# bug: http://www.postgresql.org/message-id/20130508192711.GA9243@msgid.df7cb.de
+sudo update-alternatives --remove-all postmaster.1.gz
+
+# stop all existing instances (because of https://github.com/travis-ci/travis-cookbooks/pull/221)
+sudo service postgresql stop
+# and make sure they don't come back
+echo 'exit 0' | sudo tee /etc/init.d/postgresql
+sudo chmod a+x /etc/init.d/postgresql
+
+sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install $packages
+
+export PGPORT=55435
+export PGUSER=postgres
+export PG_CONFIG=/usr/lib/postgresql/$PGVERSION/bin/pg_config
+sudo pg_createcluster --start $PGVERSION test -p $PGPORT -- -A trust
+
+make all
+
+sudo easy_install pgxnclient
+
+sudo make regress || failed=true # Don't exit yet if this failed
+
+# pg_regress --launcher not supported prior to 9.1
+echo $PGVERSION | grep -qE "8[.]|9[.][0]" || sudo make uninstall updatecheck # updatecheck depends on install, so must be sudo
+
+[ -z "$failed" ]

--- a/pgtap.control
+++ b/pgtap.control
@@ -1,6 +1,6 @@
 # pgTAP extension
 comment = 'Unit testing for PostgreSQL'
-default_version = '0.95.0'
+default_version = '0.96.0'
 module_pathname = '$libdir/pgtap'
 requires = 'plpgsql'
 relocatable = true

--- a/test/expected/build.out
+++ b/test/expected/build.out
@@ -1,0 +1,1 @@
+\unset ECHO

--- a/test/expected/create.out
+++ b/test/expected/create.out
@@ -1,0 +1,1 @@
+\unset ECHO

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -12,9 +12,9 @@ ok 9 - extensions_are(exts, desc) should have the proper diagnostics
 ok 10 - extensions_are(exts) should pass
 ok 11 - extensions_are(exts) should have the proper description
 ok 12 - extensions_are(exts) should have the proper diagnostics
-ok 13 - extensions_are(public, exts, desc) should pass
-ok 14 - extensions_are(public, exts, desc) should have the proper description
-ok 15 - extensions_are(public, exts, desc) should have the proper diagnostics
+ok 13 - extensions_are(ci_schema, exts, desc) should pass
+ok 14 - extensions_are(ci_schema, exts, desc) should have the proper description
+ok 15 - extensions_are(ci_schema, exts, desc) should have the proper diagnostics
 ok 16 - extensions_are(non-sch, exts) should pass
 ok 17 - extensions_are(non-sch, exts) should have the proper description
 ok 18 - extensions_are(non-sch, exts) should have the proper diagnostics

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -1,0 +1,4 @@
+\unset ECHO
+1..2
+ok 1 - Old version of pgtap correctly installed
+ok 2 - pgtap correctly updated

--- a/test/psql.sql
+++ b/test/psql.sql
@@ -1,0 +1,14 @@
+\set QUIET 1
+
+--
+-- Tests for pgTAP.
+--
+--
+-- Format the output for nice TAP.
+\pset format unaligned
+\pset tuples_only true
+\pset pager
+
+-- Revert all changes on failure.
+\set ON_ERROR_ROLLBACK 1
+\set ON_ERROR_STOP true

--- a/test/schedule/build.sql
+++ b/test/schedule/build.sql
@@ -1,0 +1,10 @@
+\unset ECHO
+\i test/psql.sql
+
+/*
+ * Presumably no one is installing this way anymore, but this is a nice way to
+ * pick up any syntax errors during install.
+ */
+BEGIN;
+\i sql/pgtap.sql
+ROLLBACK;

--- a/test/schedule/create.sql
+++ b/test/schedule/create.sql
@@ -1,0 +1,3 @@
+\unset ECHO
+\i test/psql.sql
+CREATE EXTENSION pgtap;

--- a/test/schedule/main.sch
+++ b/test/schedule/main.sch
@@ -1,0 +1,2 @@
+test: build
+test: create

--- a/test/schedule/update.sch
+++ b/test/schedule/update.sch
@@ -1,0 +1,1 @@
+test: update

--- a/test/schedule/update.sql
+++ b/test/schedule/update.sql
@@ -1,0 +1,20 @@
+\unset ECHO
+\i test/psql.sql
+
+CREATE EXTENSION pgtap VERSION :'old_ver';
+SELECT plan(2);
+SELECT is(
+    (SELECT extversion FROM pg_extension WHERE extname = 'pgtap')
+    , :'old_ver'
+    , 'Old version of pgtap correctly installed'
+);
+
+ALTER EXTENSION pgtap UPDATE TO :'new_ver';
+
+SELECT is(
+    (SELECT extversion FROM pg_extension WHERE extname = 'pgtap')
+    , :'new_ver'
+    , 'pgtap correctly updated'
+);
+
+SELECT finish();

--- a/test/setup.sql
+++ b/test/setup.sql
@@ -1,22 +1,3 @@
-\set QUIET 1
-
---
--- Tests for pgTAP.
---
---
--- Format the output for nice TAP.
-\pset format unaligned
-\pset tuples_only true
-\pset pager
-
--- Revert all changes on failure.
-\set ON_ERROR_ROLLBACK 1
-\set ON_ERROR_STOP true
+\i test/psql.sql
 
 BEGIN;
-
--- Uncomment when testing with PGOPTIONS=--search_path=tap
--- CREATE SCHEMA tap; SET search_path TO tap,public;
-
--- Load the TAP functions.
-\i sql/pgtap.sql

--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -1,0 +1,3 @@
+build.sql
+create.sql
+update.sql

--- a/test/sql/extension.sql
+++ b/test/sql/extension.sql
@@ -15,8 +15,9 @@ BEGIN
     IF pg_version_num() >= 90100 THEN
         EXECUTE $E$
             CREATE SCHEMA someschema;
+            CREATE SCHEMA ci_schema;
             CREATE SCHEMA "empty schema";
-            CREATE EXTENSION IF NOT EXISTS citext;
+            CREATE EXTENSION IF NOT EXISTS citext SCHEMA ci_schema;
             CREATE EXTENSION IF NOT EXISTS isn SCHEMA someschema;
             CREATE EXTENSION IF NOT EXISTS ltree SCHEMA someschema;
         $E$;
@@ -38,7 +39,7 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT* FROM check_test(
-            extensions_are( ARRAY['citext', 'isn', 'ltree', 'plpgsql'], 'Got em' ),
+            extensions_are( ARRAY['citext', 'isn', 'ltree', 'plpgsql', 'pgtap'], 'Got em' ),
             true,
             'extensions_are(exts, desc)',
             'Got em',
@@ -46,7 +47,7 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT* FROM check_test(
-            extensions_are( ARRAY['citext', 'isn', 'ltree', 'plpgsql'] ),
+            extensions_are( ARRAY['citext', 'isn', 'ltree', 'plpgsql', 'pgtap'] ),
             true,
             'extensions_are(exts)',
             'Should have the correct extensions',
@@ -54,9 +55,9 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT* FROM check_test(
-            extensions_are( 'public', ARRAY['citext'], 'Got em' ),
+            extensions_are( 'ci_schema', ARRAY['citext'], 'Got em' ),
             true,
-            'extensions_are(public, exts, desc)',
+            'extensions_are(ci_schema, exts, desc)',
             'Got em',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
@@ -83,7 +84,7 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT* FROM check_test(
-            extensions_are( ARRAY['citext', 'isn', 'ltree', 'nonesuch'] ),
+            extensions_are( ARRAY['citext', 'isn', 'ltree', 'pgtap', 'nonesuch'] ),
             false,
             'extensions_are(someexts)',
             'Should have the correct extensions',
@@ -128,7 +129,7 @@ BEGIN
         FOR tap IN SELECT * FROM check_test(
             pass('mumble'),
 	        true,
-            'extensions_are(public, exts, desc)',
+            'extensions_are(ci_schema, exts, desc)',
             'mumble',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;

--- a/test/sql/performs_ok.sql
+++ b/test/sql/performs_ok.sql
@@ -23,10 +23,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    performs_ok( 'SELECT TRUE', 99.99 ),
+    performs_ok( 'SELECT TRUE', 199.99 ),
     true,
     'simple select numeric',
-    'Should run in less than 99.99 ms',
+    'Should run in less than 199.99 ms',
     ''
 );
 

--- a/tools/parallel_conn.sh
+++ b/tools/parallel_conn.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Find the maximum safe connections for parallel execution
+
+error () {
+    echo $@ 1>&2
+}
+die () {
+    error $@
+    exit 1
+}
+
+[ $# -le 1 ] || die "$0: Invalid number of arguments"
+
+PARALLEL_CONN=$1
+
+if [ -n "$PARALLEL_CONN" ]; then
+    [ $PARALLEL_CONN -ge 1 ] 2>/dev/null || die "Invalid value for PARALLEL_CONN ($PARALLEL_CONN)"
+    echo $PARALLEL_CONN
+    exit
+fi
+
+COMMAND="SELECT greatest(1, current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int - (SELECT count(*) FROM pg_stat_activity) - 2)"
+
+if PARALLEL_CONN=`psql -d ${PGDATABASE:-postgres} -qtc "$COMMAND" 2> /dev/null`; then
+    if [ $PARALLEL_CONN -ge 1 ] 2>/dev/null; then
+        # We know it's a number at this point
+        [ $PARALLEL_CONN -eq 1 ] && error "NOTICE: unable to run tests in parallel; not enough connections"
+        echo $PARALLEL_CONN
+        exit
+    fi
+fi
+
+error "Problems encountered determining maximum parallel test connections; forcing serial mode"
+echo 1

--- a/tools/psql_args.sh
+++ b/tools/psql_args.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# This script allows for passing args to psql using pg_regress's --launcher option
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        */psql)
+            found=1
+            break
+            ;;
+        *)
+            args="$args $1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$found" ]; then
+    echo "Error: psql not found in arguments"
+    exit 1
+fi
+
+#$* $args <&0 || exit $?
+$* $args || exit $?


### PR DESCRIPTION
This is a demonstration of a working updatecheck target.

That target works by pulling down UPGRADE_FROM version of pgtap via pgxn (currently defaults to 0.94.0), installing the current version, and then doing

```
CREATE EXTENSION pgtap VERSION :'UPGRADE_FROM';
ALTER EXTENSION pgtap UPDATE :'CURRENT_VERSION';
```

then running the unit tests.

The other big change in here is that all installcheck activity is now managed with pg_regress execution schedules. There are two big wins from that:
- The extension is now loaded only once, not for every test
- Tests are now run in parallel by default (specify PARALLEL_CONN=1 to force serial)

To support that, there's now a test/build directory where temporary build objects are put.

If we're happy with this code then I'll get it into master and start hammering out the remaining upgrade issues.
