### PR TITLE
Documentation typo fix (is/isnt functions description)

### DIFF
--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -466,8 +466,8 @@ the result of that to determine if the test succeeded or failed. So these:
 
 are similar to these:
 
-    SELECT ok(   ultimate_answer() =  42, 'Meaning of Life' );
-    SELECT isnt( foo()             <> '', 'Got some foo'    );
+    SELECT ok( ultimate_answer() =  42, 'Meaning of Life' );
+    SELECT ok( foo() <> '', 'Got some foo' );
 
 (Mnemonic: "This is that." "This isn't that.")
 


### PR DESCRIPTION
Hey guys, I have found a minor glitch in `pgtap` documentation while reading it. Here is the fix :)