### PR TITLE
Specify ordering in partitions_are(NAME, NAME[], TEXT)

### DIFF
--- a/compat/install-9.6.patch
+++ b/compat/install-9.6.patch
@@ -120,8 +120,8 @@
 -RETURNS TEXT AS $$
 -    SELECT _are(
 -        'partitions',
--        ARRAY(SELECT _parts($1) EXCEPT SELECT unnest($2)),
--        ARRAY(SELECT unnest($2) EXCEPT SELECT _parts($1)),
+-        ARRAY(SELECT _parts($1) EXCEPT SELECT unnest($2) ORDER BY 1),
+-        ARRAY(SELECT unnest($2) EXCEPT SELECT _parts($1) ORDER BY 1),
 -        $3
 -    );
 -$$ LANGUAGE SQL;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -10006,8 +10006,8 @@ CREATE OR REPLACE FUNCTION partitions_are( NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT _are(
         'partitions',
-        ARRAY(SELECT _parts($1) EXCEPT SELECT unnest($2)),
-        ARRAY(SELECT unnest($2) EXCEPT SELECT _parts($1)),
+        ARRAY(SELECT _parts($1) EXCEPT SELECT unnest($2) ORDER BY 1),
+        ARRAY(SELECT unnest($2) EXCEPT SELECT _parts($1) ORDER BY 1),
         $3
     );
 $$ LANGUAGE SQL;

--- a/test/sql/partitions.sql
+++ b/test/sql/partitions.sql
@@ -300,9 +300,9 @@ SELECT * FROM check_test(
     'partitions_are( hidden tab, parts, desc )',
     'hi',
     '    Missing partitions:
-        not_hidden_part3
+        "hide.hidden_part1"
         "hide.hidden_part2"
-        "hide.hidden_part1"'
+        not_hidden_part3'
 );
 
 -- Should not work for unpartitioned but inherited table


### PR DESCRIPTION
This makes the test results deterministic.

This fixes https://github.com/theory/pgtap/issues/158