### PR TITLE
Fix partition checking

### DIFF
--- a/compat/install-9.6.patch
+++ b/compat/install-9.6.patch
@@ -100,8 +100,8 @@
 -RETURNS TEXT AS $$
 -    SELECT _are(
 -        'partitions',
--        ARRAY(SELECT _parts($1, $2) EXCEPT SELECT unnest($3)),
--        ARRAY(SELECT unnest($3) EXCEPT SELECT _parts($1, $2)),
+-        ARRAY((SELECT _parts($1, $2)::text collate "C" EXCEPT SELECT unnest($3)) ORDER BY 1),
+-        ARRAY((SELECT unnest($3)::text collate "C" EXCEPT SELECT _parts($1, $2)) ORDER BY 1),
 -        $4
 -    );
 -$$ LANGUAGE SQL;
@@ -120,8 +120,8 @@
 -RETURNS TEXT AS $$
 -    SELECT _are(
 -        'partitions',
--        ARRAY(SELECT _parts($1) EXCEPT SELECT unnest($2)),
--        ARRAY(SELECT unnest($2) EXCEPT SELECT _parts($1)),
+-        ARRAY((SELECT _parts($1)::text collate "C" EXCEPT SELECT unnest($2)) ORDER BY 1),
+-        ARRAY((SELECT unnest($2)::text collate "C" EXCEPT SELECT _parts($1)) ORDER BY 1),
 -        $3
 -    );
 -$$ LANGUAGE SQL;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -9986,8 +9986,8 @@ CREATE OR REPLACE FUNCTION partitions_are( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT _are(
         'partitions',
-        ARRAY(SELECT _parts($1, $2) EXCEPT SELECT unnest($3)),
-        ARRAY(SELECT unnest($3) EXCEPT SELECT _parts($1, $2)),
+        ARRAY((SELECT _parts($1, $2)::text collate "C" EXCEPT SELECT unnest($3)) ORDER BY 1),
+        ARRAY((SELECT unnest($3)::text collate "C" EXCEPT SELECT _parts($1, $2)) ORDER BY 1),
         $4
     );
 $$ LANGUAGE SQL;
@@ -10006,8 +10006,8 @@ CREATE OR REPLACE FUNCTION partitions_are( NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT _are(
         'partitions',
-        ARRAY(SELECT _parts($1) EXCEPT SELECT unnest($2)),
-        ARRAY(SELECT unnest($2) EXCEPT SELECT _parts($1)),
+        ARRAY((SELECT _parts($1)::text collate "C" EXCEPT SELECT unnest($2)) ORDER BY 1),
+        ARRAY((SELECT unnest($2)::text collate "C" EXCEPT SELECT _parts($1)) ORDER BY 1),
         $3
     );
 $$ LANGUAGE SQL;

--- a/test/sql/partitions.sql
+++ b/test/sql/partitions.sql
@@ -300,9 +300,9 @@ SELECT * FROM check_test(
     'partitions_are( hidden tab, parts, desc )',
     'hi',
     '    Missing partitions:
-        not_hidden_part3
+        "hide.hidden_part1"
         "hide.hidden_part2"
-        "hide.hidden_part1"'
+        not_hidden_part3'
 );
 
 -- Should not work for unpartitioned but inherited table


### PR DESCRIPTION
Now return string of partitions_are are sorted with a reproducible order
(collate C)

This should fix build error seen in #153 , which seems to be a coincidence