### PR TITLE
fix: generation of uninstall script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ ifeq ($(shell echo $(VERSION) | grep -qE "^(9[.][012]|8[.][1234])" && echo yes |
 endif
 
 sql/uninstall_pgtap.sql: sql/pgtap.sql test/setup.sql
-	grep '^CREATE ' sql/pgtap.sql | $(PERL) -e 'for (reverse <STDIN>) { chomp; s/CREATE (OR REPLACE)?/DROP/; print "$$_;\n" }' > sql/uninstall_pgtap.sql
+	grep '^CREATE ' sql/pgtap.sql | $(PERL) -e 'for (reverse <STDIN>) { chomp; s/CREATE (OR REPLACE )?/DROP /; print "$$_;\n" }' > sql/uninstall_pgtap.sql
 
 sql/pgtap-static.sql: sql/pgtap.sql.in
 	cp $< $@


### PR DESCRIPTION
Current regexp replace generates 'DROPTYPE' in uninstall script for
'_time_trial_type'. Adding ' ' to both pattern and replacement fix this.