### PR TITLE
documentation -- fix test_user function example

### DIFF
--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -323,7 +323,6 @@ values. Here's an example, testing a hypothetical `users` table:
     CREATE OR REPLACE FUNCTION test_user(
     ) RETURNS SETOF TEXT AS $$
        SELECT is( nick, 'theory', 'Should have nick') FROM users;
-    END;
     $$ LANGUAGE sql;
 
 See below for details on the pgTAP assertion functions. Once you've defined


### PR DESCRIPTION
Remove orphan `END;` from the `test_user` function as it causes a syntax error upon execution.  Presumably it's there from a bad copy and paste because the function `LANGUAGE` is query language (SQL).