### PR TITLE
Fix make results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - sudo rm -vf /etc/apt/sources.list.d/pgdg-source.list
 script:
   - bash ./pg-travis-test.sh
-
 env:
   # WARNING! UPGRADE_TO tests pg_upgrade; UDPATE_FROM tests ALTER EXTENSION! Note UPGRADE vs UPDATE!
   - UPGRADE_TO=9.2 PGVERSION=9.1

--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,14 @@ regress: installcheck_deps
 updatecheck: updatecheck_deps install
 	$(MAKE) updatecheck_run || ([ -e regression.diffs ] && $${PAGER:-cat} regression.diffs; exit 1)
 
+# Runs installcheck but doesn't bomb on error. Used as a dependency for `make
+# results`. The other way to do this would be to add the installcheck target to
+# .IGNORE, like pgxntools does. I've opted not to do that since people may be
+# depending on the current behavior. :(
+.PHONY: installcheck_nofail
+installcheck_nofail: installcheck_deps
+	$(MAKE) installcheck || true
+
 # General dependencies for installcheck. Note that several other places add themselves as dependencies.
 .PHONY: installcheck_deps
 installcheck_deps: $(SCHEDULE_DEST_FILES) extension_check set_parallel_conn # More dependencies below
@@ -479,7 +487,7 @@ updatecheck_run: updatecheck_setup installcheck
 
 # TARGET results: runs `make test` and copies all result files to test/expected/. DO NOT RUN THIS UNLESS YOU'RE CERTAIN ALL YOUR TESTS ARE PASSING!
 .PHONY: results
-results: installcheck result-rsync
+results: installcheck_nofail result-rsync
 
 .PHONY:
 result-rsync:

--- a/test/expected/runjusttests.out
+++ b/test/expected/runjusttests.out
@@ -25,6 +25,7 @@ ok 3 - whatever.testplpgsql
     #         CONSTRAINT: CONSTRAINT
     #         TYPE:       TYPE
     #         CONTEXT:
+    #             PL/pgSQL function __die() line 3 at RAISE
     #             SQL statement "SELECT __die();"
     #             PL/pgSQL function whatever.testplpgsqldie() line 43 at EXECUTE
     #             PL/pgSQL function _runner(text[],text[],text[],text[],text[]) line 62 at FOR over EXECUTE statement

--- a/test/expected/runtests.out
+++ b/test/expected/runtests.out
@@ -35,6 +35,7 @@ ok 4 - whatever.testplpgsql
     #         CONSTRAINT: CONSTRAINT
     #         TYPE:       TYPE
     #         CONTEXT:
+    #             PL/pgSQL function __die() line 3 at RAISE
     #             SQL statement "SELECT __die();"
     #             PL/pgSQL function whatever.testplpgsqldie() line 23 at EXECUTE
     #             PL/pgSQL function _runner(text[],text[],text[],text[],text[]) line 62 at FOR over EXECUTE statement
@@ -113,6 +114,7 @@ ok 4 - whatever.testplpgsql
     #         CONSTRAINT: CONSTRAINT
     #         TYPE:       TYPE
     #         CONTEXT:
+    #             PL/pgSQL function __die() line 3 at RAISE
     #             SQL statement "SELECT __die();"
     #             PL/pgSQL function whatever.testplpgsqldie() line 23 at EXECUTE
     #             PL/pgSQL function _runner(text[],text[],text[],text[],text[]) line 62 at FOR over EXECUTE statement


### PR DESCRIPTION
The recently added make results target doesn't work, because by default make installcheck aborts make if the test fails. Add a installcheck_no_fail target that uses a separate make process and some shell trickery to avoid this.