### PR TITLE
Run tests after pg_upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ test-parallel: extension_check set_parallel_conn
 	@echo Running pg_prove on PARALLEL tests
 	pg_prove -f --pset tuples_only=1 \
 		-j $(PARALLEL_CONN) \
-		$(PG_PROVE_PARALLEL_FILES)
+		$(PG_PROVE_PARALLEL_FILES) -v
 
 .PHONY: test
 test: test-serial test-parallel

--- a/Makefile
+++ b/Makefile
@@ -341,15 +341,15 @@ installcheck_deps: $(SCHEDULE_DEST_FILES) extension_check set_parallel_conn # Mo
 .PHONY: test-serial
 test-serial: extension_check
 	@echo Running pg_prove on SERIAL tests
-	pg_prove -f --pset tuples_only=1 \
+	pg_prove --pset tuples_only=1 \
 		$(PG_PROVE_SERIAL_FILES)
 
 .PHONY: test-parallel
 test-parallel: extension_check set_parallel_conn
 	@echo Running pg_prove on PARALLEL tests
-	pg_prove -f --pset tuples_only=1 \
+	pg_prove --pset tuples_only=1 \
 		-j $(PARALLEL_CONN) \
-		$(PG_PROVE_PARALLEL_FILES) -v
+		$(PG_PROVE_PARALLEL_FILES)
 
 .PHONY: test
 test: test-serial test-parallel

--- a/Makefile
+++ b/Makefile
@@ -341,13 +341,13 @@ installcheck_deps: $(SCHEDULE_DEST_FILES) extension_check set_parallel_conn # Mo
 .PHONY: test-serial
 test-serial: extension_check
 	@echo Running pg_prove on SERIAL tests
-	pg_prove --pset tuples_only=1 \
+	pg_prove -f --pset tuples_only=1 \
 		$(PG_PROVE_SERIAL_FILES)
 
 .PHONY: test-parallel
 test-parallel: extension_check set_parallel_conn
 	@echo Running pg_prove on PARALLEL tests
-	pg_prove --pset tuples_only=1 \
+	pg_prove -f --pset tuples_only=1 \
 		-j $(PARALLEL_CONN) \
 		$(PG_PROVE_PARALLEL_FILES)
 

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -20,7 +20,7 @@ get_path() {
 
 # Do NOT use () here; we depend on being able to set failed
 test_cmd() (
-local status rc
+#local status rc
 if [ "$1" == '-s' ]; then
     status="$2"
     shift 2

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -80,12 +80,11 @@ update() {
     echo $PGVERSION | grep -qE "8[.]|9[.][012]" || test_make clean updatecheck
 }
 
-tests_run_by_target_all=5
+tests_run_by_target_all=11 # 1 + 5 * 2
 all() {
     # the test* targets use pg_prove, which assumes it's making a default psql
     # connection to a database that has pgTap installed, so we need to set that
     # up.
-    test_cmd createdb
     test_cmd psql -Ec 'CREATE EXTENSION pgtap'
 
     # TODO: install software necessary to allow testing 'html' target
@@ -150,7 +149,7 @@ done
 
 pg_
 
-# You can use this to check tests 
+# You can use this to check tests that are failing pg_prove
 pg_prove -f --pset tuples_only=1 test/sql/unique.sql test/sql/check.sql || true
 
 if [ $tests_run -eq $total_tests ]; then

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -4,8 +4,8 @@
 
 set -E -e -u -o pipefail 
 
-export DEBUG=1
-set -x
+#export DEBUG=1
+#set -x
 
 export UPGRADE_TO=${UPGRADE_TO:-}
 failed=''
@@ -21,7 +21,7 @@ get_path() {
 }
 
 # Do NOT use () here; we depend on being able to set failed
-test_cmd() (
+test_cmd() {
 #local status rc
 if [ "$1" == '-s' ]; then
     status="$2"
@@ -38,7 +38,6 @@ echo ###########################################################################
 rc=0
 ( "$@" ) || rc=$?
 if [ $rc -ne 0 ]; then
-    echo test >&2
     echo
     echo '!!!!!!!!!!!!!!!! FAILURE !!!!!!!!!!!!!!!!'
     echo "$@" returned $rc
@@ -46,12 +45,12 @@ if [ $rc -ne 0 ]; then
     echo
     failed="$failed '$status'"
 fi
-)
+}
 
 # Ensure test_cmd sets failed properly
 test_cmd fail > /dev/null 2>&1
 if [ -z "$failed" ]; then
-    echo "test_cmd did not set \$failed"
+    echo "code error: test_cmd() did not set \$failed"
     exit 91
 fi
 failed=''

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -74,8 +74,10 @@ update() {
     echo $PGVERSION | grep -qE "8[.]|9[.][012]" || test_make clean updatecheck
 }
 
+tests_run_by_target_all=5
 all() {
 # TODO: install software necessary to allow testing 'html' target
+# UPDATE tests_run_by_target_all IF YOU ADD ANY TESTS HERE!
 for t in all install test test-serial test-parallel ; do
     # Test from a clean slate...
     test_make uninstall clean $t
@@ -129,14 +131,16 @@ sudo pg_createcluster --start $PGVERSION test -p $PGPORT -- -A trust
 sudo easy_install pgxnclient
 
 set +x
+total_tests=$((3 + $tests_run_by_target_all))
 for t in ${TARGETS:-sanity update upgrade all}; do
     $t
 done
 
-if [ $tests_run -gt 0 ]; then
-    plural=''
-    [ $tests_run -eq 1 ] || plural='s'
-    echo Ran $tests_run test$plural
+if [ $tests_run -eq $total_tests ]; then
+    echo Ran $tests_run tests
+elif [ $tests_run -gt 0 ]; then
+    echo "WARNING! ONLY RAN $tests_run OUT OF $total_tests TESTS!"
+    # We don't consider this an error...
 else
     echo No tests were run!
     exit 2

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -4,6 +4,12 @@
 
 set -E -e -u -o pipefail 
 
+#
+# NOTE: you can control what tests run by setting the TARGETS environment
+# variable for a particular branch in the Travis console
+#
+
+# You can set this to higher levels for more debug output
 #export DEBUG=1
 #set -x
 
@@ -76,14 +82,20 @@ update() {
 
 tests_run_by_target_all=5
 all() {
-# TODO: install software necessary to allow testing 'html' target
-# UPDATE tests_run_by_target_all IF YOU ADD ANY TESTS HERE!
-for t in all install test test-serial test-parallel ; do
-    # Test from a clean slate...
-    test_make uninstall clean $t
-    # And then test again
-    test_make $t
-done
+    # the test* targets use pg_prove, which assumes it's making a default psql
+    # connection to a database that has pgTap installed, so we need to set that
+    # up.
+    test_cmd createdb
+    test_cmd psql -Ec 'CREATE EXTENSION pgtap'
+
+    # TODO: install software necessary to allow testing 'html' target
+    # UPDATE tests_run_by_target_all IF YOU ADD ANY TESTS HERE!
+    for t in all install test test-serial test-parallel ; do
+        # Test from a clean slate...
+        test_make uninstall clean $t
+        # And then test again
+        test_make $t
+    done
 }
 
 upgrade() {

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -11,7 +11,7 @@ export UPGRADE_TO=${UPGRADE_TO:-}
 sudo apt-get update
 
 get_packages() {
-    echo "postgresql-$1 postgresql-server-dev-$1"
+    echo "libtap-parser-sourcehandler-pgtap-perl postgresql-$1 postgresql-server-dev-$1"
 }
 get_path() {
     # See also test/test_MVU.sh

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -2,7 +2,7 @@
 
 # Based on https://gist.github.com/petere/6023944
 
-set -eux
+set -E -e -u -o pipefail 
 failed=''
 
 export DEBUG=1
@@ -26,7 +26,6 @@ else
     status="$1"
 fi
 
-set +ux
 echo
 echo #############################################################################
 echo "PG-TRAVIS: running $@"
@@ -34,7 +33,6 @@ echo ###########################################################################
 # Use || so as not to trip up -e
 rc=0
 "$@" || rc=$?
-set -ux
 if [ $rc -ne 0 ]; then
     echo
     echo '!!!!!!!!!!!!!!!! FAILURE !!!!!!!!!!!!!!!!'
@@ -108,7 +106,6 @@ if [ -n "$UPGRADE_TO" ]; then
 fi
 
 if [ -n "$failed" ]; then
-    set +ux
     # $failed will have a leading space if it's not empty
     echo "These test targets failed:$failed"
     exit 1

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -147,8 +147,6 @@ for t in ${TARGETS:-sanity update upgrade all}; do
     $t
 done
 
-pg_
-
 # You can use this to check tests that are failing pg_prove
 pg_prove -f --pset tuples_only=1 test/sql/unique.sql test/sql/check.sql || true
 

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -148,6 +148,11 @@ for t in ${TARGETS:-sanity update upgrade all}; do
     $t
 done
 
+pg_
+
+# You can use this to check tests 
+pg_prove -f --pset tuples_only=1 test/sql/unique.sql test/sql/check.sql || true
+
 if [ $tests_run -eq $total_tests ]; then
     echo Ran $tests_run tests
 elif [ $tests_run -gt 0 ]; then

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -31,14 +31,15 @@ echo
 echo #############################################################################
 echo "PG-TRAVIS: running $@"
 echo #############################################################################
-"$@"
-rc=$?
+# Use || so as not to trip up -e
+rc=0
+"$@" || rc=$?
 set -ux
 if [ $rc -ne 0 ]; then
     echo
-    echo '!!!!!!!!!!!!!!!!'
-    echo "$@"
-    echo '!!!!!!!!!!!!!!!!'
+    echo '!!!!!!!!!!!!!!!! FAILURE !!!!!!!!!!!!!!!!'
+    echo "$@" returned $rc
+    echo '!!!!!!!!!!!!!!!! FAILURE !!!!!!!!!!!!!!!!'
     echo
     failed="$failed '$status'"
 fi
@@ -91,9 +92,11 @@ echo $PGVERSION | grep -qE "8[.]|9[.][012]" || test_make clean updatecheck
 
 # Explicitly test these other targets
 
-# TODO: install software necessary to allow testing the 'test' and 'html' targets
-for t in all install ; do
-    test_make clean $t
+# TODO: install software necessary to allow testing 'html' target
+for t in all install test ; do
+    # Test from a clean slate...
+    test_make uninstall clean $t
+    # And then test again
     test_make $t
 done
 

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -5,7 +5,7 @@
 set -eux
 failed=''
 
-#export DEBUG=1
+export DEBUG=1
 export UPGRADE_TO=${UPGRADE_TO:-}
 
 sudo apt-get update

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -5,7 +5,7 @@
 set -eux
 failed=''
 
-#export DEBUG=9
+#export DEBUG=1
 export UPGRADE_TO=${UPGRADE_TO:-}
 
 sudo apt-get update

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -3,10 +3,12 @@
 # Based on https://gist.github.com/petere/6023944
 
 set -E -e -u -o pipefail 
-failed=''
 
 export DEBUG=1
+set -x
+
 export UPGRADE_TO=${UPGRADE_TO:-}
+failed=''
 
 sudo apt-get update
 
@@ -90,6 +92,7 @@ sudo pg_createcluster --start $PGVERSION test -p $PGPORT -- -A trust
 
 sudo easy_install pgxnclient
 
+set +x
 test_make clean regress
 
 # pg_regress --launcher not supported prior to 9.1

--- a/pg-travis-test.sh
+++ b/pg-travis-test.sh
@@ -38,7 +38,7 @@ echo ###########################################################################
 rc=0
 ( "$@" ) || rc=$?
 if [ $rc -ne 0 ]; then
-    error test
+    echo test >&2
     echo
     echo '!!!!!!!!!!!!!!!! FAILURE !!!!!!!!!!!!!!!!'
     echo "$@" returned $rc
@@ -50,7 +50,10 @@ fi
 
 # Ensure test_cmd sets failed properly
 test_cmd fail > /dev/null 2>&1
-[ -n "$failed" ] || die 91 "test_cmd did not set \$failed"
+if [ -z "$failed" ]; then
+    echo "test_cmd did not set \$failed"
+    exit 91
+fi
 failed=''
 
 test_make() {

--- a/sql/pgtap--1.0.0--1.1.0.sql
+++ b/sql/pgtap--1.0.0--1.1.0.sql
@@ -103,3 +103,28 @@ CREATE OR REPLACE FUNCTION col_is_null (
     SELECT _col_is_null( $1, $2, $3, false );
 $$ LANGUAGE SQL;
 
+-- _keys( schema, table, constraint_type )
+CREATE OR REPLACE FUNCTION _keys ( NAME, NAME, CHAR )
+RETURNS SETOF NAME[] AS $$
+    SELECT _pg_sv_column_array(x.conrelid,x.conkey) -- name[] doesn't support collation
+      FROM pg_catalog.pg_namespace n
+      JOIN pg_catalog.pg_class c       ON n.oid = c.relnamespace
+      JOIN pg_catalog.pg_constraint x  ON c.oid = x.conrelid
+     WHERE n.nspname = $1
+       AND c.relname = $2
+       AND x.contype = $3
+  ORDER BY 1
+$$ LANGUAGE sql;
+
+-- _keys( table, constraint_type )
+CREATE OR REPLACE FUNCTION _keys ( NAME, CHAR )
+RETURNS SETOF NAME[] AS $$
+    SELECT _pg_sv_column_array(x.conrelid,x.conkey) -- name[] doesn't support collation
+      FROM pg_catalog.pg_class c
+      JOIN pg_catalog.pg_constraint x  ON c.oid = x.conrelid
+       AND c.relname = $1
+       AND x.contype = $2
+     WHERE pg_catalog.pg_table_is_visible(c.oid)
+  ORDER BY 1
+$$ LANGUAGE sql;
+

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1930,24 +1930,26 @@ AS
 -- _keys( schema, table, constraint_type )
 CREATE OR REPLACE FUNCTION _keys ( NAME, NAME, CHAR )
 RETURNS SETOF NAME[] AS $$
-    SELECT _pg_sv_column_array(x.conrelid,x.conkey)
+    SELECT _pg_sv_column_array(x.conrelid,x.conkey) -- name[] doesn't support collation
       FROM pg_catalog.pg_namespace n
       JOIN pg_catalog.pg_class c       ON n.oid = c.relnamespace
       JOIN pg_catalog.pg_constraint x  ON c.oid = x.conrelid
      WHERE n.nspname = $1
        AND c.relname = $2
        AND x.contype = $3
+  ORDER BY 1
 $$ LANGUAGE sql;
 
 -- _keys( table, constraint_type )
 CREATE OR REPLACE FUNCTION _keys ( NAME, CHAR )
 RETURNS SETOF NAME[] AS $$
-    SELECT _pg_sv_column_array(x.conrelid,x.conkey)
+    SELECT _pg_sv_column_array(x.conrelid,x.conkey) -- name[] doesn't support collation
       FROM pg_catalog.pg_class c
       JOIN pg_catalog.pg_constraint x  ON c.oid = x.conrelid
        AND c.relname = $1
        AND x.contype = $2
      WHERE pg_catalog.pg_table_is_visible(c.oid)
+  ORDER BY 1
 $$ LANGUAGE sql;
 
 -- _ckeys( schema, table, constraint_type )

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -349,7 +349,7 @@ export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)
 # because they test functions not available in the previous version.
 int_ver() {
     local ver
-    ver=$(echo $1 | tr -d.)
+    ver=$(echo $1 | tr -d .)
     # "multiply" versions less than 7.0 by 10 so that version 10.x becomes 100,
     # 11 becomes 110, etc.
     [ $ver -ge 70 ] || ver="${ver}0"

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -334,7 +334,7 @@ $new_pg_ctl start $ctl_separator -w || die $? "$new_pg_ctl start $ctl_separator 
 $new_pg_ctl status # Should error if not running on most versions
 
 psql -E -c '\dx'
-psql -E -c 'SELECT pg_tap_version()'
+psql -E -c 'SELECT pgtap_version()'
 
 # We want to make sure to use the NEW pg_config
 export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -285,27 +285,29 @@ export PGDATA=$new_dir
 export PGPORT=$NEW_PORT
 modify_config $NEW_VERSION
 
-cd $upgrade_dir
-if [ $DEBUG -ge 9 ]; then
-    echo $old_dir; ls -la $old_dir; egrep 'director|unix|conf' $old_dir/postgresql.conf
-    echo $new_dir; ls -la $new_dir; egrep 'director|unix|conf' $new_dir/postgresql.conf
-fi
-echo $new_pg_upgrade -d "$old_dir" -D "$new_dir" -b "$OLD_PATH" -B "$NEW_PATH"
-$new_pg_upgrade -d "$old_dir" -D "$new_dir" -b "$OLD_PATH" -B "$NEW_PATH" || rc=$?
-if [ $rc -ne 0 ]; then
-    # Dump log, but only if we're not keeping the directory
-    if [ -z "$keep" ]; then
-        for f in `ls *.log`; do
-            echo; echo; echo; echo; echo; echo
-            echo "`pwd`/$f:"
-            cat "$f"
-        done
-        ls -la
-    else
-        error "pg_upgrade logs are at $upgrade_dir"
+(
+    cd $upgrade_dir
+    if [ $DEBUG -ge 9 ]; then
+        echo $old_dir; ls -la $old_dir; egrep 'director|unix|conf' $old_dir/postgresql.conf
+        echo $new_dir; ls -la $new_dir; egrep 'director|unix|conf' $new_dir/postgresql.conf
     fi
-    die $rc "pg_upgrade returned $rc"
-fi
+    echo $new_pg_upgrade -d "$old_dir" -D "$new_dir" -b "$OLD_PATH" -B "$NEW_PATH"
+    $new_pg_upgrade -d "$old_dir" -D "$new_dir" -b "$OLD_PATH" -B "$NEW_PATH" || rc=$?
+    if [ $rc -ne 0 ]; then
+        # Dump log, but only if we're not keeping the directory
+        if [ -z "$keep" ]; then
+            for f in `ls *.log`; do
+                echo; echo; echo; echo; echo; echo
+                echo "`pwd`/$f:"
+                cat "$f"
+            done
+            ls -la
+        else
+            error "pg_upgrade logs are at $upgrade_dir"
+        fi
+        die $rc "pg_upgrade returned $rc"
+    fi
+)
 
 
 

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -319,4 +319,7 @@ status=$($old_pg_ctl status) || rc=$?
 [ $rc -eq 3 -a "$status" == 'pg_ctl: no server running' ] || die 3 "$old_pg_ctl status returned '$status' and exited with $?"
 debug 1 "$old_pg_ctl status returned $status"
 
-( cd $(dirname $0)/..; make test )
+# We want to make sure to use the NEW pg_config
+export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)
+[ -x "$PG_CONFIG" ] || ( debug_ls 1 "$NEW_PATH"; die 4 "unable to find executable pg_config at $NEW_PATH" )
+( cd $(dirname $0)/.. && make clean test )

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -339,7 +339,7 @@ $new_pg_ctl start $ctl_separator -w || die $? "$new_pg_ctl start $ctl_separator 
 $new_pg_ctl status # Should error if not running on most versions
 
 psql -E -c '\dx'
-psql -E -c 'SELECT pgtap_version()'
+psql -E -c 'SELECT pgtap_version(), pg_version_num(), version();'
 
 # We want to make sure to use the NEW pg_config
 export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)
@@ -369,6 +369,7 @@ add_exclude() {
 add_exclude 9.4 9.5 test/sql/policy.sql test/sql/throwtap.sql 
 add_exclude 9.6 10 test/sql/partitions.sql
 
+# Use this if there's a single test failing in Travis that you can't figure out...
 (cd $(dirname $0)/..; pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
 
 export EXCLUDE_TEST_FILES

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -316,15 +316,16 @@ banner "Testing UPGRADED cluster"
 
 # Run our tests against the upgraded cluster, but first make sure the old
 # cluster is still down, to ensure there's no chance of testing it instead.
+# Note that some versions of pg_ctl return different exit codes when the server
+# isn't running.
 rc=0
 status=$($old_pg_ctl status) || rc=$?
-[ $rc -eq 3 -a "$status" == 'pg_ctl: no server running' ] || die 3 "$old_pg_ctl status returned '$status' and exited with $?"
-debug 1 "$old_pg_ctl status returned $status"
+[ "$status" == 'pg_ctl: no server running' ] || die 3 "$old_pg_ctl status returned '$status' and exited with $?"
+debug 4 "$old_pg_ctl status exited with $rc"
+
+$new_pg_ctl start $ctl_separator -w || die $? "$new_pg_ctl start $ctl_separator -w returned $?"
 
 # We want to make sure to use the NEW pg_config
 export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)
 [ -x "$PG_CONFIG" ] || ( debug_ls 1 "$NEW_PATH"; die 4 "unable to find executable pg_config at $NEW_PATH" )
-pwd
-ls -la
-ls -la ..
 ( cd $(dirname $0)/.. && make clean test )

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -369,7 +369,7 @@ add_exclude() {
 add_exclude 9.4 9.5 test/sql/policy.sql test/sql/throwtap.sql 
 add_exclude 9.6 10 test/sql/partitions.sql
 
-(cd $(dirname $0); pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
+(cd $(dirname $0)/..; pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
 
 export EXCLUDE_TEST_FILES
 run_make clean test

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -314,7 +314,7 @@ banner "Testing UPGRADED cluster"
 
 # Run our tests against the upgraded cluster, but first make sure the old
 # cluster is still down, to ensure there's no chance of testing it instead.
-status=$($old_pg_ctl status) || die 3 "$old_pg_ctl status exited with $?"
+status=$($old_pg_ctl status) || die 3 "$old_pg_ctl status returned '$status' but exited with $?"
 debug 1 "$old_pg_ctl status returned $status"
 [ "$status" == 'pg_ctl: no server running' ] || die 3 "old cluster is still running
 

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -372,6 +372,7 @@ add_exclude 9.6 10 test/sql/partitions.sql
 export EXCLUDE_TEST_FILES
 run_make clean test
 
+(cd $(dirname $0); pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
 if [ -n "$EXCLUDE_TEST_FILES" ]; then
     banner "Rerunning test after a reinstall due to version differences"
     echo "Excluded tests: $EXCLUDE_TEST_FILES"

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -322,4 +322,7 @@ debug 1 "$old_pg_ctl status returned $status"
 # We want to make sure to use the NEW pg_config
 export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)
 [ -x "$PG_CONFIG" ] || ( debug_ls 1 "$NEW_PATH"; die 4 "unable to find executable pg_config at $NEW_PATH" )
+pwd
+ls -la
+ls -la ..
 ( cd $(dirname $0)/.. && make clean test )

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -207,6 +207,11 @@ exit_trap() {
     # Force sudo on a debian system (see below)
     [ -z "$ctl_separator" ] || sudo=$(which sudo)
 
+    # Attempt to shut down any running clusters, otherwise we'll get log spew
+    # when the temporary directories vanish.
+    $old_pg_ctl stop 2> /dev/null
+    $new_pg_ctl stop 2> /dev/null
+
     # Do not simply stick this command in the trap command; the quoting gets
     # tricky, but the quoting is also damn critical to make sure rm -rf doesn't
     # hose you if the temporary directory names have spaces in them!

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -374,7 +374,7 @@ run_make clean test
 
 if [ -n "$EXCLUDE_TEST_FILES" ]; then
     banner "Rerunning test after a reinstall due to version differences"
-    echo "Excluded tests: $EXCLUDED_TEST_FILES"
+    echo "Excluded tests: $EXCLUDE_TEST_FILES"
     export EXCLUDED_TEST_FILES=''
 
     # Need to build with the new version, then install

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -369,10 +369,11 @@ add_exclude() {
 add_exclude 9.4 9.5 test/sql/policy.sql test/sql/throwtap.sql 
 add_exclude 9.6 10 test/sql/partitions.sql
 
+(cd $(dirname $0); pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
+
 export EXCLUDE_TEST_FILES
 run_make clean test
 
-(cd $(dirname $0); pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
 if [ -n "$EXCLUDE_TEST_FILES" ]; then
     banner "Rerunning test after a reinstall due to version differences"
     echo "Excluded tests: $EXCLUDE_TEST_FILES"

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -325,6 +325,8 @@ debug 4 "$old_pg_ctl status exited with $rc"
 
 $new_pg_ctl start $ctl_separator -w || die $? "$new_pg_ctl start $ctl_separator -w returned $?"
 
+$new_pg_ctl status # Should error if not running on most versions
+
 # We want to make sure to use the NEW pg_config
 export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)
 [ -x "$PG_CONFIG" ] || ( debug_ls 1 "$NEW_PATH"; die 4 "unable to find executable pg_config at $NEW_PATH" )

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -209,8 +209,8 @@ exit_trap() {
 
     # Attempt to shut down any running clusters, otherwise we'll get log spew
     # when the temporary directories vanish.
-    $old_pg_ctl stop 2> /dev/null
-    $new_pg_ctl stop 2> /dev/null
+    $old_pg_ctl stop > /dev/null 2>&1
+    $new_pg_ctl stop > /dev/null 2>&1
 
     # Do not simply stick this command in the trap command; the quoting gets
     # tricky, but the quoting is also damn critical to make sure rm -rf doesn't
@@ -232,17 +232,17 @@ if which pg_ctlcluster > /dev/null 2>&1; then
     export PGUSER=$USER
 
     old_initdb="sudo pg_createcluster $OLD_VERSION $cluster_name -u $USER -p $OLD_PORT -d $old_dir -- -A trust"
+    old_pg_ctl="sudo pg_ctlcluster $OLD_VERSION test_pg_upgrade"
     new_initdb="sudo pg_createcluster $NEW_VERSION $cluster_name -u $USER -p $NEW_PORT -d $new_dir -- -A trust"
-    old_pg_ctl="sudo pg_ctlcluster $PGVERSION test_pg_upgrade"
-    new_pg_ctl=$old_pg_ctl
+    new_pg_ctl="sudo pg_ctlcluster $NEW_VERSION test_pg_upgrade"
+
     # See also ../pg-travis-test.sh
     new_pg_upgrade=/usr/lib/postgresql/$NEW_VERSION/bin/pg_upgrade
 else
     ctl_separator=''
     old_initdb="$(find_at_path "$OLD_PATH" initdb) -D $old_dir -N"
-    new_initdb="$(find_at_path "$NEW_PATH" initdb) -D $new_dir -N"
-    # s/initdb/pg_ctl/g
     old_pg_ctl=$(find_at_path "$OLD_PATH" pg_ctl)
+    new_initdb="$(find_at_path "$NEW_PATH" initdb) -D $new_dir -N"
     new_pg_ctl=$(find_at_path "$NEW_PATH" pg_ctl)
 
     new_pg_upgrade=$(find_at_path "$NEW_PATH" pg_upgrade)

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -366,11 +366,12 @@ add_exclude() {
     fi
 }
 
+add_exclude 9.1 9.2 test/sql/throwtap.sql
 add_exclude 9.4 9.5 test/sql/policy.sql test/sql/throwtap.sql 
 add_exclude 9.6 10 test/sql/partitions.sql
 
 # Use this if there's a single test failing in Travis that you can't figure out...
-(cd $(dirname $0)/..; pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
+#(cd $(dirname $0)/..; pg_prove -v --pset tuples_only=1 test/sql/throwtap.sql)
 
 export EXCLUDE_TEST_FILES
 run_make clean test

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -309,10 +309,6 @@ fi
 
 
 
-# TODO: turn this stuff on. It's pointless to test via `make regress` because
-# that creates a new install; need to figure out the best way to test the new
-# cluster
-exit
 ##################################################################################################
 banner "Testing UPGRADED cluster"
 
@@ -324,4 +320,4 @@ debug 1 "$old_pg_ctl status returned $status"
 
 $old_pg_ctl status returned
 $status"
-( cd $(dirname $0)/..; $sudo make clean regress )
+( cd $(dirname $0)/..; make test )

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -323,14 +323,18 @@ banner "Testing UPGRADED cluster"
 # cluster is still down, to ensure there's no chance of testing it instead.
 # Note that some versions of pg_ctl return different exit codes when the server
 # isn't running.
+echo ensuring OLD cluster is stopped
 rc=0
 status=$($old_pg_ctl status) || rc=$?
 [ "$status" == 'pg_ctl: no server running' ] || die 3 "$old_pg_ctl status returned '$status' and exited with $?"
 debug 4 "$old_pg_ctl status exited with $rc"
 
+echo starting NEW cluster
 $new_pg_ctl start $ctl_separator -w || die $? "$new_pg_ctl start $ctl_separator -w returned $?"
-
 $new_pg_ctl status # Should error if not running on most versions
+
+psql -E -c '\dx'
+psql -E -c 'SELECT pg_tap_version()'
 
 # We want to make sure to use the NEW pg_config
 export PG_CONFIG=$(find_at_path "$NEW_PATH" pg_config)

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -314,10 +314,9 @@ banner "Testing UPGRADED cluster"
 
 # Run our tests against the upgraded cluster, but first make sure the old
 # cluster is still down, to ensure there's no chance of testing it instead.
-status=$($old_pg_ctl status) || die 3 "$old_pg_ctl status returned '$status' but exited with $?"
+rc=0
+status=$($old_pg_ctl status) || rc=$?
+[ $rc -eq 3 -a "$status" == 'pg_ctl: no server running' ] || die 3 "$old_pg_ctl status returned '$status' and exited with $?"
 debug 1 "$old_pg_ctl status returned $status"
-[ "$status" == 'pg_ctl: no server running' ] || die 3 "old cluster is still running
 
-$old_pg_ctl status returned
-$status"
 ( cd $(dirname $0)/..; make test )


### PR DESCRIPTION
Modify `test/test_MVU.sh` to run tests against pgTap after running `pg_upgrade`. Additionally:

- Minor improvements to Makefile, including running pg_prove with multiple jobs for tests that support parallelism
- Refactor `pg-travis-test.sh`; add explicit tests for `test`, `test-serial`, and `test-parallel`.
- Make output ordering of `_keys()` deterministic. This was uncovered by multiple runs of the `test*` targets against the same database.