### PR TITLE
Fixes additional test failures that require quote_ident().

### DIFF
--- a/test/sql/ownership.sql
+++ b/test/sql/ownership.sql
@@ -71,7 +71,7 @@ SELECT * FROM check_test(
     db_owner_is(current_database(), current_user),
 	true,
     'db_owner_is(db, user)',
-    'Database ' || quote_ident(current_database()) || ' should be owned by ' || current_user,
+    'Database ' || quote_ident(current_database()) || ' should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -141,7 +141,7 @@ SELECT * FROM check_test(
     relation_owner_is('public', 'sometab', current_user),
 	true,
     'relation_owner_is(sch, tab, user)',
-    'Relation public.sometab should be owned by ' || current_user,
+    'Relation public.sometab should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -173,7 +173,7 @@ SELECT * FROM check_test(
     relation_owner_is('sometab', current_user),
 	true,
     'relation_owner_is(tab, user)',
-    'Relation sometab should be owned by ' || current_user,
+    'Relation sometab should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -199,7 +199,7 @@ SELECT * FROM check_test(
     relation_owner_is('public', 'apart', current_user),
 	true,
     'relation_owner_is(sch, part, user)',
-    'Relation public.apart should be owned by ' || current_user,
+    'Relation public.apart should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -231,7 +231,7 @@ SELECT * FROM check_test(
     relation_owner_is('apart', current_user),
 	true,
     'relation_owner_is(part, user)',
-    'Relation apart should be owned by ' || current_user,
+    'Relation apart should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -257,7 +257,7 @@ SELECT * FROM check_test(
     relation_owner_is('public', 'someseq', current_user),
 	true,
     'relation_owner_is(sch, seq, user)',
-    'Relation public.someseq should be owned by ' || current_user,
+    'Relation public.someseq should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -289,7 +289,7 @@ SELECT * FROM check_test(
     relation_owner_is('someseq', current_user),
 	true,
     'relation_owner_is(seq, user)',
-    'Relation someseq should be owned by ' || current_user,
+    'Relation someseq should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -315,7 +315,7 @@ SELECT * FROM check_test(
     table_owner_is('public', 'sometab', current_user),
 	true,
     'table_owner_is(sch, tab, user)',
-    'Table public.sometab should be owned by ' || current_user,
+    'Table public.sometab should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -347,7 +347,7 @@ SELECT * FROM check_test(
     table_owner_is('sometab', current_user),
 	true,
     'table_owner_is(tab, user)',
-    'Table sometab should be owned by ' || current_user,
+    'Table sometab should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -407,7 +407,7 @@ SELECT * FROM check_test(
     view_owner_is('public', 'someview', current_user),
 	true,
     'view_owner_is(sch, view, user)',
-    'View public.someview should be owned by ' || current_user,
+    'View public.someview should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -439,7 +439,7 @@ SELECT * FROM check_test(
     view_owner_is('someview', current_user),
 	true,
     'view_owner_is(view, user)',
-    'View someview should be owned by ' || current_user,
+    'View someview should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -482,7 +482,7 @@ SELECT * FROM check_test(
     sequence_owner_is('public', 'someseq', current_user),
 	true,
     'sequence_owner_is(sch, sequence, user)',
-    'Sequence public.someseq should be owned by ' || current_user,
+    'Sequence public.someseq should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -514,7 +514,7 @@ SELECT * FROM check_test(
     sequence_owner_is('someseq', current_user),
 	true,
     'sequence_owner_is(sequence, user)',
-    'Sequence someseq should be owned by ' || current_user,
+    'Sequence someseq should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -557,7 +557,7 @@ SELECT * FROM check_test(
     composite_owner_is('public', 'sometype', current_user),
 	true,
     'composite_owner_is(sch, composite, user)',
-    'Composite type public.sometype should be owned by ' || current_user,
+    'Composite type public.sometype should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -589,7 +589,7 @@ SELECT * FROM check_test(
     composite_owner_is('sometype', current_user),
 	true,
     'composite_owner_is(composite, user)',
-    'Composite type sometype should be owned by ' || current_user,
+    'Composite type sometype should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -643,7 +643,7 @@ BEGIN
             foreign_table_owner_is('public', 'my_fdw', current_user),
 	        true,
             'foreign_table_owner_is(sch, tab, user)',
-            'Foreign table public.my_fdw should be owned by ' || current_user,
+            'Foreign table public.my_fdw should be owned by ' || quote_ident(current_user),
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
@@ -675,7 +675,7 @@ BEGIN
             foreign_table_owner_is('my_fdw', current_user),
 	        true,
             'foreign_table_owner_is(tab, user)',
-            'Foreign table my_fdw should be owned by ' || current_user,
+            'Foreign table my_fdw should be owned by ' || quote_ident(current_user),
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
@@ -798,7 +798,7 @@ SELECT * FROM check_test(
     function_owner_is('public', 'somefunction', ARRAY['integer'], current_user),
 	true,
     'function_owner_is(sch, function, args[integer], user)',
-    'Function public.somefunction(integer) should be owned by ' || current_user,
+    'Function public.somefunction(integer) should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -814,7 +814,7 @@ SELECT * FROM check_test(
     function_owner_is('public', 'test_fdw', '{}'::NAME[], current_user),
 	true,
     'function_owner_is(sch, function, args[], user)',
-    'Function public.test_fdw() should be owned by ' || current_user,
+    'Function public.test_fdw() should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -830,7 +830,7 @@ SELECT * FROM check_test(
     function_owner_is('somefunction', ARRAY['integer'], current_user),
 	true,
     'function_owner_is(function, args[integer], user)',
-    'Function somefunction(integer) should be owned by ' || current_user,
+    'Function somefunction(integer) should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -846,7 +846,7 @@ SELECT * FROM check_test(
     function_owner_is('test_fdw', '{}'::NAME[], current_user),
 	true,
     'function_owner_is(function, args[], user)',
-    'Function test_fdw() should be owned by ' || current_user,
+    'Function test_fdw() should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -942,7 +942,7 @@ SELECT * FROM check_test(
     index_owner_is('someschema', 'anothertab', 'idx_name', current_user),
 	true,
     'index_owner_is(schema, table, index, user)',
-    'Index idx_name ON someschema.anothertab should be owned by ' || current_user,
+    'Index idx_name ON someschema.anothertab should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -999,7 +999,7 @@ SELECT * FROM check_test(
     index_owner_is('sometab', 'idx_hey', current_user),
 	true,
     'index_owner_is(table, index, user)',
-    'Index idx_hey ON sometab should be owned by ' || current_user,
+    'Index idx_hey ON sometab should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -1213,7 +1213,7 @@ SELECT * FROM check_test(
     type_owner_is('someschema', 'us_postal_code', current_user),
 	true,
     'type_owner_is(schema, type, user)',
-    'Type someschema.us_postal_code should be owned by ' || current_user,
+    'Type someschema.us_postal_code should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -1262,7 +1262,7 @@ SELECT * FROM check_test(
     type_owner_is('sometype', current_user),
 	true,
     'type_owner_is(type, user)',
-    'Type sometype should be owned by ' || current_user,
+    'Type sometype should be owned by ' || quote_ident(current_user),
     ''
 );
 
@@ -1308,7 +1308,7 @@ BEGIN
             materialized_view_owner_is('public', 'somemview', current_user),
             true,
             'materialized_view_owner_is(sch, materialized_view, user)',
-            'Materialized view public.somemview should be owned by ' || current_user,
+            'Materialized view public.somemview should be owned by ' || quote_ident(current_user),
             ''
         ) AS b LOOP
                     RETURN NEXT tap.b;
@@ -1348,7 +1348,7 @@ BEGIN
             materialized_view_owner_is('somemview', current_user),
             true,
             'materialized_view_owner_is(view, user)',
-            'Materialized view somemview should be owned by ' || current_user,
+            'Materialized view somemview should be owned by ' || quote_ident(current_user),
             ''
         ) AS b LOOP
                     RETURN NEXT tap.b;
@@ -1400,7 +1400,7 @@ BEGIN
             view_owner_is('public', 'someview', current_user),
             true,
             'materialized_view_owner_is(sch, materialized_view, user)',
-            'View public.someview should be owned by ' || current_user,
+            'View public.someview should be owned by ' || quote_ident(current_user),
             ''
         ) AS b LOOP
                     RETURN NEXT tap.b;
@@ -1440,7 +1440,7 @@ BEGIN
             view_owner_is('someview', current_user),
             true,
             'materialized_view_owner_is(view, user)',
-            'View someview should be owned by ' || current_user,
+            'View someview should be owned by ' || quote_ident(current_user),
             ''
         ) AS b LOOP
                     RETURN NEXT tap.b;

--- a/test/sql/privs.sql
+++ b/test/sql/privs.sql
@@ -51,7 +51,7 @@ SELECT * FROM check_test(
     table_privs_are( 'ha', 'sometab', current_user, _table_privs() ),
     true,
     'table_privs_are(sch, tab, role, privs)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(_table_privs(), ', ') || ' on table ha.sometab' ,
     ''
 );
@@ -60,7 +60,7 @@ SELECT * FROM check_test(
     table_privs_are( 'LOL', 'ATable', current_user, _table_privs() ),
     true,
     'table_privs_are(LOL, ATable, role, privs)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(_table_privs(), ', ') || ' on table "LOL"."ATable"' ,
     ''
 );
@@ -85,7 +85,7 @@ SELECT * FROM check_test(
     table_privs_are( 'sometab', current_user, _table_privs() ),
     true,
     'table_privs_are(tab, role, privs)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(_table_privs(), ', ') || ' on table sometab' ,
     ''
 );
@@ -94,7 +94,7 @@ SELECT * FROM check_test(
     table_privs_are( 'ATable', current_user, _table_privs() ),
     true,
     'table_privs_are(ATable, role, privs)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(_table_privs(), ', ') || ' on table "ATable"' ,
     ''
 );
@@ -214,7 +214,7 @@ SELECT * FROM check_test(
     database_privs_are( current_database(), current_user, _db_privs() ),
     true,
     'database_privs_are(db, role, privs, desc)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(_db_privs(), ', ') || ' on database ' || quote_ident( current_database() ),
     ''
 );
@@ -304,7 +304,7 @@ SELECT * FROM check_test(
     ),
     true,
     'function_privs_are(sch, func, args, role, privs)',
-    'Role ' || current_user || ' should be granted EXECUTE on function public.foo(integer, text)'
+    'Role ' || quote_ident(current_user) || ' should be granted EXECUTE on function public.foo(integer, text)'
     ''
 );
 
@@ -315,7 +315,7 @@ SELECT * FROM check_test(
     ),
     true,
     'function_privs_are(LOL, DoIt, args, role, privs)',
-    'Role ' || current_user || ' should be granted EXECUTE on function "LOL"."DoIt"(integer, text)'
+    'Role ' || quote_ident(current_user) || ' should be granted EXECUTE on function "LOL"."DoIt"(integer, text)'
     ''
 );
 
@@ -348,7 +348,7 @@ SELECT * FROM check_test(
     ),
     true,
     'function_privs_are(func, args, role, privs)',
-    'Role ' || current_user || ' should be granted EXECUTE on function foo(integer, text)'
+    'Role ' || quote_ident(current_user) || ' should be granted EXECUTE on function foo(integer, text)'
     ''
 );
 
@@ -359,7 +359,7 @@ SELECT * FROM check_test(
     ),
     true,
     'function_privs_are(DoIt, args, role, privs)',
-    'Role ' || current_user || ' should be granted EXECUTE on function "DoIt"(integer, text)'
+    'Role ' || quote_ident(current_user) || ' should be granted EXECUTE on function "DoIt"(integer, text)'
     ''
 );
 
@@ -550,7 +550,7 @@ SELECT * FROM check_test(
     language_privs_are( 'plpgsql', current_user, '{USAGE}' ),
     true,
     'language_privs_are(lang, role, privs, desc)',
-    'Role ' || current_user || ' should be granted USAGE on language plpgsql',
+    'Role ' || quote_ident(current_user) || ' should be granted USAGE on language plpgsql',
     ''
 );
 
@@ -615,7 +615,7 @@ SELECT * FROM check_test(
     schema_privs_are( current_schema(), current_user, ARRAY['CREATE', 'USAGE'] ),
     true,
     'schema_privs_are(schema, role, privs, desc)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(ARRAY['CREATE', 'USAGE'], ', ') || ' on schema ' || current_schema(),
     ''
 );
@@ -624,7 +624,7 @@ SELECT * FROM check_test(
     schema_privs_are( 'LOL', current_user, ARRAY['CREATE', 'USAGE'] ),
     true,
     'schema_privs_are(LOL, role, privs, desc)',
-    'Role ' || current_user || ' should be granted '
+    'Role ' || quote_ident(current_user) || ' should be granted '
          || array_to_string(ARRAY['CREATE', 'USAGE'], ', ') || ' on schema "LOL"',
     ''
 );
@@ -695,7 +695,7 @@ SELECT * FROM check_test(
     tablespace_privs_are( 'pg_default', current_user, '{CREATE}' ),
     true,
     'tablespace_privs_are(tablespace, role, privs, desc)',
-    'Role ' || current_user || ' should be granted CREATE on tablespace pg_default',
+    'Role ' || quote_ident(current_user) || ' should be granted CREATE on tablespace pg_default',
     ''
 );
 
@@ -773,7 +773,7 @@ BEGIN
             sequence_privs_are( 'ha', 'someseq', current_user, ARRAY['USAGE', 'SELECT', 'UPDATE'] ),
             true,
             'sequence_privs_are(sch, seq, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['USAGE', 'SELECT', 'UPDATE'], ', ')
                 || ' on sequence ha.someseq' ,
             ''
@@ -783,7 +783,7 @@ BEGIN
             sequence_privs_are( 'LOL', 'ASeq', current_user, ARRAY['USAGE', 'SELECT', 'UPDATE'] ),
             true,
             'sequence_privs_are(sch, seq, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['USAGE', 'SELECT', 'UPDATE'], ', ')
                 || ' on sequence "LOL"."ASeq"' ,
             ''
@@ -813,7 +813,7 @@ BEGIN
             sequence_privs_are( 'someseq', current_user, ARRAY['USAGE', 'SELECT', 'UPDATE'] ),
             true,
             'sequence_privs_are(seq, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['USAGE', 'SELECT', 'UPDATE'], ', ')
                 || ' on sequence someseq' ,
             ''
@@ -823,7 +823,7 @@ BEGIN
             sequence_privs_are( 'ASeq', current_user, ARRAY['USAGE', 'SELECT', 'UPDATE'] ),
             true,
             'sequence_privs_are(seq, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['USAGE', 'SELECT', 'UPDATE'], ', ')
                 || ' on sequence "ASeq"' ,
             ''
@@ -1085,7 +1085,7 @@ BEGIN
             ] ),
             true,
             'any_column_privs_are(sch, tab, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['INSERT', 'REFERENCES', 'SELECT', 'UPDATE'], ', ')
                 || ' on any column in ha.sometab' ,
             ''
@@ -1107,7 +1107,7 @@ BEGIN
             ] ),
             true,
             'any_column_privs_are(tab, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['INSERT', 'REFERENCES', 'SELECT', 'UPDATE'], ', ')
                 || ' on any column in sometab' ,
             ''
@@ -1345,7 +1345,7 @@ BEGIN
             ] ),
             true,
             'column_privs_are(sch, tab, col, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['INSERT', 'REFERENCES', 'SELECT', 'UPDATE'], ', ')
                 || ' on column ha.sometab.id' ,
             ''
@@ -1357,7 +1357,7 @@ BEGIN
             ] ),
             true,
             'column_privs_are(LOL, ATable, AColumn, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['INSERT', 'REFERENCES', 'SELECT', 'UPDATE'], ', ')
                 || ' on column "LOL"."ATable"."AColumn"' ,
             ''
@@ -1389,7 +1389,7 @@ BEGIN
             ] ),
             true,
             'column_privs_are(tab, col, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['INSERT', 'REFERENCES', 'SELECT', 'UPDATE'], ', ')
                 || ' on column sometab.id' ,
                 ''
@@ -1401,7 +1401,7 @@ BEGIN
             ] ),
             true,
             'column_privs_are(tab, col, role, privs)',
-            'Role ' || current_user || ' should be granted '
+            'Role ' || quote_ident(current_user) || ' should be granted '
                 || array_to_string(ARRAY['INSERT', 'REFERENCES', 'SELECT', 'UPDATE'], ', ')
                 || ' on column "ATable"."AColumn"' ,
                 ''
@@ -1668,7 +1668,7 @@ BEGIN
             fdw_privs_are( 'dummy', current_user, '{USAGE}' ),
             true,
             'fdw_privs_are(fdw, role, privs, desc)',
-            'Role ' || current_user || ' should be granted USAGE on FDW dummy',
+            'Role ' || quote_ident(current_user) || ' should be granted USAGE on FDW dummy',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
@@ -1676,7 +1676,7 @@ BEGIN
             fdw_privs_are( 'SomeFDW', current_user, '{USAGE}' ),
             true,
             'fdw_privs_are(SomeFDW, role, privs, desc)',
-            'Role ' || current_user || ' should be granted USAGE on FDW "SomeFDW"',
+            'Role ' || quote_ident(current_user) || ' should be granted USAGE on FDW "SomeFDW"',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
@@ -1826,7 +1826,7 @@ BEGIN
             server_privs_are( 'foo', current_user, '{USAGE}' ),
             true,
             'server_privs_are(server, role, privs, desc)',
-            'Role ' || current_user || ' should be granted USAGE on server foo',
+            'Role ' || quote_ident(current_user) || ' should be granted USAGE on server foo',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
@@ -1834,7 +1834,7 @@ BEGIN
             server_privs_are( 'SomeServer', current_user, '{USAGE}' ),
             true,
             'server_privs_are(SomeServer, role, privs, desc)',
-            'Role ' || current_user || ' should be granted USAGE on server "SomeServer"',
+            'Role ' || quote_ident(current_user) || ' should be granted USAGE on server "SomeServer"',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 

--- a/test/sql/roletap.sql
+++ b/test/sql/roletap.sql
@@ -103,7 +103,7 @@ SELECT * FROM check_test(
     'roles_are(roles, desc) extras',
     'whatever',
     '    Extra roles:
-        ' || current_role
+        ' || quote_ident(current_role)
 );
 
 SELECT * FROM check_test(
@@ -112,7 +112,7 @@ SELECT * FROM check_test(
     'roles_are(roles, desc) missing and extras',
     'whatever',
     '    Extra roles:
-        ' || current_role || '
+        ' || quote_ident(current_role) || '
     Missing roles:
         __howdy__'
 );

--- a/test/sql/usergroup.sql
+++ b/test/sql/usergroup.sql
@@ -185,7 +185,7 @@ SELECT * FROM check_test(
 -- Test is_member_of().
 CREATE OR REPLACE FUNCTION addmember() RETURNS SETOF TEXT AS $$
 BEGIN
-    EXECUTE 'ALTER GROUP meanies ADD USER ' || current_user;
+    EXECUTE 'ALTER GROUP meanies ADD USER ' || quote_ident(current_user);
     RETURN;
 END;
 $$ LANGUAGE PLPGSQL;    


### PR DESCRIPTION
Follow up to #216 (fixed in 007ee2f). Fixes additional test failures
where the current username must be quoted as an identifier.