### PR TITLE
Remove old stuff

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,9 @@ Revision history for pgTAP
   identifier. Thanks to Matt DeLuco for the report (#216)!
 * Fixed the `col_not_null()` drop statements in the uninstall script. Thanks
   to Kyle L. Jensen for the report (#252).
+* Removed straggler references to Postgres 9.0 and earlier, including conditional
+  tests.
+* Updated all relevant URLs to use https instead of http.
 
 1.1.0 2019-11-25T19:05:38Z
 --------------------------
@@ -220,7 +223,7 @@ Revision history for pgTAP
     + `has_foreign_table(:schema, :table)`
     + `hasnt_foreign_table(:schema, :table)`
 * Fixed the format of SKIP output to match the
-  [TAP spec](http://podwiki.hexten.net/TAP/TAP.html#Skippingtests).
+  [TAP spec](https://testanything.org/tap-specification.html#skipping-tests).
 * Fixed incorrect handling of leading space when comparing diagnostic output
   in `check_test()`.
 * Fixed an installation issue on PostgreSQL 9.3.2.
@@ -373,7 +376,7 @@ Revision history for pgTAP
 * Removed `pg_prove` and `pg_tapgen` from the distribution. They must now be
   installed separately from CPAN. If it's not installed, the intaller will
   issue a warning.
-* Added `META.json` and distributed on [PGXN](http://pgxn.org/).
+* Added `META.json` and distributed on [PGXN](https://pgxn.org/).
 * Rearranged the source directory layout to more closely match the [preferred
   PGXN layout](http://manager.pgxn.org/howto#new-order).
 
@@ -814,4 +817,4 @@ Revision history for pgTAP
 0.01  2008-06-07T05:24:27Z
 --------------------------
 * Initial public release. Announcement at
-  http://justatheory.com/computers/databases/postgresql/introducing_pgtap.html
+  https://justatheory.com/2008/06/introducing-pgtap/

--- a/META.json
+++ b/META.json
@@ -8,7 +8,7 @@
       "pgTAP List <pgtap-users@pgfoundry.org>"
    ],
    "license": {
-      "PostgreSQL": "http://www.postgresql.org/about/licence"
+      "PostgreSQL": "https://www.postgresql.org/about/licence"
    },
    "prereqs": {
       "runtime": {
@@ -39,7 +39,7 @@
      }
    },
    "resources": {
-      "homepage": "http://pgtap.org/",
+      "homepage": "https://pgtap.org/",
       "bugtracker": {
          "web": "https://github.com/theory/pgtap/issues"
       },
@@ -52,7 +52,7 @@
    "generated_by": "David E. Wheeler",
    "meta-spec": {
       "version": "1.0.0",
-      "url": "http://pgxn.org/meta/spec.txt"
+      "url": "https://pgxn.org/meta/spec.txt"
    },
    "tags": [
       "testing",

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 pgTAP 1.1.0
 ============
 
-[pgTAP](http://pgtap.org) is a unit testing framework for PostgreSQL written
+[pgTAP](https://pgtap.org) is a unit testing framework for PostgreSQL written
 in PL/pgSQL and PL/SQL. It includes a comprehensive collection of
-[TAP](http://testanything.org)-emitting assertion functions, as well as the
+[TAP](https://testanything.org)-emitting assertion functions, as well as the
 ability to integrate with other TAP-emitting test frameworks. It can also be
 used in the xUnit testing style. For detailed documentation, see the
 documentation in `doc/pgtap.mmd` or
-[online](http://pgtap.org/documentation.html "Complete pgTAP Documentation").
+[online](https://pgtap.org/documentation.html "Complete pgTAP Documentation").
 
 [![PGXN version](https://badge.fury.io/pg/pgtap.svg)](https://badge.fury.io/pg/pgtap)
 [![Build Status](https://travis-ci.org/theory/pgtap.png)](https://travis-ci.org/theory/pgtap)
@@ -35,7 +35,7 @@ If you encounter an error such as:
 
 Or:
 
-    Makefile:52: *** pgTAP requires PostgreSQL 8.1 or later. This is .  Stop.
+    Makefile:52: *** pgTAP requires PostgreSQL 9.1 or later. This is .  Stop.
 
 Be sure that you have `pg_config` installed and in your path. If you used a
 package management system such as RPM to install PostgreSQL, be sure that the
@@ -44,9 +44,9 @@ to find it:
 
     env PG_CONFIG=/path/to/pg_config make && make install && make installcheck
 
-And finally, if all that fails (and if you're on PostgreSQL 8.1, it likely
-will), copy the entire distribution directory to the `contrib/` subdirectory
-of the PostgreSQL source tree and try it there without `pg_config`:
+And finally, if all that fails, copy the entire distribution directory to the
+`contrib/` subdirectory of the PostgreSQL source tree and try it there without
+`pg_config`:
 
     env NO_PGXS=1 make && make install && make installcheck
 
@@ -59,9 +59,8 @@ You need to run the test suite using a super user, such as the default
 
     make installcheck PGUSER=postgres
 
-Once pgTAP is installed, you can add it to a database. If you're running
-PostgreSQL 9.1.0 or greater, it's a simple as connecting to a database as a
-super user and running:
+Once pgTAP is installed, you can add it to a database by connecting as a super
+user and running:
 
     CREATE EXTENSION pgtap;
 
@@ -70,22 +69,21 @@ installed, you can upgrade it to a properly packaged extension with:
 
     CREATE EXTENSION pgtap FROM unpackaged;
 
-For versions of PostgreSQL less than 9.1.0, you'll need to run the
-installation script:
-
-    psql -d mydb -f /path/to/pgsql/share/contrib/pgtap.sql
-
 If you want to install pgTAP and all of its supporting objects into a
 specific schema, use the `PGOPTIONS` environment variable to specify the
 schema, like so:
 
     PGOPTIONS=--search_path=tap psql -d mydb -f pgTAP.sql
 
+If you want to install pgTAP and all of its supporting objects into a specific
+schema, use the `SCHEMA` clause to specify the schema, like so:
+
+    CREATE EXTENSION pgtap SCHEMA tap;
+
 Dependencies
 ------------
 
-pgTAP requires PostgreSQL 8.1 or higher, with 8.4 or higher recommended for
-full use of its API. It also requires PL/pgSQL.
+pgTAP requires PostgreSQL 9.1 or higher.
 
 Copyright and License
 ---------------------

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pgTAP requires PostgreSQL 9.1 or higher.
 Copyright and License
 ---------------------
 
-Copyright (c) 2008-2018 David E. Wheeler. Some rights reserved.
+Copyright (c) 2008-2020 David E. Wheeler. Some rights reserved.
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement is

--- a/compat/gencore
+++ b/compat/gencore
@@ -15,7 +15,7 @@ print qq{
 -- project is:
 
 --
--- http://pgtap.org/
+-- https://pgtap.org/
 --
 
 };

--- a/contrib/pgtap.spec
+++ b/contrib/pgtap.spec
@@ -1,11 +1,11 @@
-Summary:	Unit testing suite for PostgreSQL
-Name:		pgtap
-Version:	1.1.0
-Release:	1%{?dist}
-Group:		Applications/Databases
-License:	PostgreSQL
-URL:		http://pgtap.org/
-Source0:	http://master.pgxn.org/dist/pgtap/%{version}/pgtap-%{version}.zip
+Summary:	  Unit testing suite for PostgreSQL
+Name:		    pgtap
+Version:	  1.1.0
+Release:	  2%{?dist}
+Group:		  Applications/Databases
+License:	  PostgreSQL
+URL:		    https://pgtap.org/
+Source0:	  https://master.pgxn.org/dist/pgtap/%{version}/pgtap-%{version}.zip
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
 Provides:   %{name}
 Provides:   %{name}-core
@@ -22,10 +22,6 @@ Requires:       postgresql-server = %{postgresver}, perl-Test-Harness >= 3.0
 Requires:       perl(TAP::Parser::SourceHandler::pgTAP)
 BuildRequires:	postgresql-devel = %{postgresver}
 
-%if "%{postgresver}" != "8.4"
-BuildArch:	noarch
-%endif
- 
 %prep
 %setup -q
 
@@ -41,18 +37,19 @@ make install USE_PGXS=1 DESTDIR=%{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%if "%{postgresver}" == "8.3"
-%{_libdir}/pgsql/pgtap.so
-%endif
 %{_datadir}/pgsql/contrib/*
 %{_docdir}/pgsql/contrib/README.pgtap
 
 %changelog
-* Mon Nov 25 2019 Jim Nasby <nasbyj@amazon.com> 1.1.0
+* Sat Oct 24 2020 Jim Nasby <nasbyj@amazon.com> 1.1.0-2
+- Remove last vestiges of pre-PostgreSQL 9.1
+- Use https for URLs
+
+* Mon Nov 25 2019 Jim Nasby <nasbyj@amazon.com> 1.1.0-1
 - Update to 1.1.0
 - Remove support for PostgreSQL prior to 9.1
 
-* Thu Feb 21 2019 Jim Nasby <jim@nasby.net> 1.0.0
+* Thu Feb 21 2019 Jim Nasby <jim@nasby.net> 1.0.0-1
 - Update to 1.0.0
 
 * Sun Sep 16 2018 David E. Wheeler <david@justatheory.com> 0.99.0-1

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -8338,7 +8338,7 @@ Credits
 Copyright and License
 ---------------------
 
-Copyright (c) 2008-2018 David E. Wheeler. Some rights reserved.
+Copyright (c) 2008-2020 David E. Wheeler. Some rights reserved.
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement is

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -62,7 +62,7 @@ If you encounter an error such as:
     "Makefile", line 8: Need an operator
 
 You need to use GNU make, which may well be installed on your system as
-'gmake':
+`gmake`:
 
     gmake
     gmake install
@@ -74,7 +74,7 @@ If you encounter an error such as:
 
 Or:
 
-    Makefile:52: *** pgTAP requires PostgreSQL 8.1 or later. This is .  Stop.
+    Makefile:52: *** pgTAP requires PostgreSQL 9.1 or later. This is .  Stop.
 
 Be sure that you have `pg_config` installed and in your path. If you used a
 package management system such as RPM to install PostgreSQL, be sure that the
@@ -83,9 +83,9 @@ to find it:
 
     env PG_CONFIG=/path/to/pg_config make && make install && make installcheck
 
-And finally, if all that fails (and if you're on PostgreSQL 8.1, it likely
-will), copy the entire distribution directory to the `contrib/` subdirectory
-of the PostgreSQL source tree and try it there without `pg_config`:
+And finally, if all that fails, copy the entire distribution directory to the
+`contrib/` subdirectory of the PostgreSQL source tree and try it there without
+`pg_config`:
 
     env NO_PGXS=1 make && make install && make installcheck
 
@@ -97,6 +97,27 @@ You need to run the test suite using a super user, such as the default
 "postgres" super user:
 
     make installcheck PGUSER=postgres
+
+Once pgTAP is installed, you can add it to a database by connecting as a super
+user and running:
+
+    CREATE EXTENSION pgtap;
+
+If you've upgraded your cluster to PostgreSQL 9.1 and already had pgTAP
+installed, you can upgrade it to a properly packaged extension with:
+
+    CREATE EXTENSION pgtap FROM unpackaged;
+
+If you want to install pgTAP and all of its supporting objects into a
+specific schema, use the `PGOPTIONS` environment variable to specify the
+schema, like so:
+
+    PGOPTIONS=--search_path=tap psql -d mydb -f pgTAP.sql
+
+If you want to install pgTAP and all of its supporting objects into a specific
+schema, use the `SCHEMA` clause to specify the schema, like so:
+
+    CREATE EXTENSION pgtap SCHEMA tap;
 
 Testing pgTAP with pgTAP
 ------------------------
@@ -500,7 +521,7 @@ Will produce something like this:
 So you can figure out what went wrong without re-running the test.
 
 You are encouraged to use `is()` and `isnt()` over `ok()` where possible. You
-can even use them to compare records in PostgreSQL 8.4 and later:
+can even use them to compare records:
 
     SELECT is( users.*, ROW(1, 'theory', true)::users )
       FROM users
@@ -1273,25 +1294,13 @@ will be represented as "NULL":
     #         have: (1,Anna)
     #         want: NULL
 
-On PostgreSQL 8.4 or higher, if the number of columns varies between result
-sets, or if results are of different data types, you'll get diagnostics like
-so:
+If the number of columns varies between result sets, or if results are of
+different data types, you'll get diagnostics like so:
 
     # Failed test 148
     #     Number of columns or their types differ between the queries:
     #         have: (1)
     #         want: (foo,1)
-
-On PostgreSQL 8.3 and down, the rows are cast to text for comparison, rather
-than compared as `record` objects. The downside to this necessity is that the
-test cannot detect incompatibilities in column numbers or types, or
-differences in columns that convert to the same text representation. For
-example, a `NULL` column will be equivalent to an empty string. As a result,
-pgTAP will not show the `have` and `want` values if they are the same, just
-the error message, like so:
-
-    # Failed test 149
-    #     Number of columns or their types differ between the queries
 
 ### `results_ne()` ###
 
@@ -1330,9 +1339,6 @@ want is `results_eq()` or `set_ne()`. But this function is included for
 completeness and is kind of cute, so enjoy. If a `results_ne()` test fails,
 however, there will be no diagnostics, because, well, the results will be the
 same!
-
-Note that the caveats for `results_ne()` on PostgreSQL 8.3 and down apply to
-`results_ne()` as well.
 
 ### `set_eq()` ###
 
@@ -2501,10 +2507,9 @@ missing domains, like so:
 : A short description of the test.
 
 Tests that all of the enums in the named schema are the only enums in that
-schema. Enums are supported in PostgreSQL 8.3 and up. If the `:schema`
-argument is omitted, the enums must be visible in the search path, excluding
-`pg_catalog` and `information_schema`. If the description is omitted, a
-generally useful default description will be generated. Example:
+schema. If the `:schema` argument is omitted, the enums must be visible in the
+search path, excluding `pg_catalog` and `information_schema`. If the description
+is omitted, a generally useful default description will be generated. Example:
 
     SELECT enums_are('myschema', ARRAY[ 'timezone', 'state' ]);
 
@@ -3413,11 +3418,11 @@ domain does *not* exist.
 `:description`
 : A short description of the test.
 
-This function tests whether or not a enum exists in the database. Enums are
-supported in PostgreSQL 8.3 or higher. The first argument is a schema name,
-the second is the an enum name, and the third is the test description. If you
-omit the schema, the enum must be visible in the search path. If you omit the
-test description, it will be set to "Enum `:enum` should exist". Example:
+This function tests whether or not a enum exists in the database. The first
+argument is a schema name, the second is the an enum name, and the third is the
+test description. If you omit the schema, the enum must be visible in the search
+path. If you omit the test description, it will be set to "Enum `:enum` should
+exist". Example:
 
     SELECT has_enum( 'myschema', 'someenum' );
 
@@ -4425,9 +4430,7 @@ that this test will fail if the table or column in question does not exist.
 The default argument must have an unambiguous type in order for the call to
 succeed. If you see an error such as 'ERROR: could not determine polymorphic
 type because input has type "unknown"', it's because you forgot to cast the
-expected value, probably a `NULL` (which, by the way, you can only properly
-test for in PostgreSQL 8.3 and later), to its proper type. IOW, this will
-fail:
+expected value, probably a `NULL`, to its proper type. IOW, this will fail:
 
     SELECT col_default_is( 'tab', age, NULL );
 
@@ -5707,10 +5710,9 @@ far.
 `:description`
 : A short description of the test.
 
-This function tests that an enum consists of an expected list of labels. Enums
-are supported in PostgreSQL 8.3 or higher. The first argument is a schema
-name, the second an enum name, the third an array of enum labels, and the
-fourth a description. Example:
+This function tests that an enum consists of an expected list of labels.The
+first argument is a schema name, the second an enum name, the third an array of
+enum labels, and the fourth a description. Example:
 
     SELECT enum_has_labels( 'myschema', 'someenum', ARRAY['foo', 'bar'] );
 
@@ -6552,9 +6554,8 @@ diagnostics will look something like:
 `:description`
 : A short description of the test.
 
-Tests the ownership of a procedural language. If the `:description` argument
-is omitted, an appropriate description will be created. Works on PostgreSQL
-8.3 and higher. Examples:
+Tests the ownership of a procedural language. If the `:description` argument is
+omitted, an appropriate description will be created. Examples:
 
     SELECT language_owner_is( 'plpgsql', 'larry', 'Larry should own plpgsql' );
     SELECT language_owner_is( 'plperl', current_user );
@@ -6887,9 +6888,6 @@ table privileges are:
 * TRUNCATE
 * UPDATE
 
-Note that the privilege RULE is not available after PostgreSQL 8.1, and that
-TRIGGER was added in 8.4.
-
 If the `:description` argument is omitted, an appropriate description will be
 created. Examples:
 
@@ -7033,9 +7031,6 @@ The available column privileges are:
 * SELECT
 * UPDATE
 
-Note that column privileges were added in PostgreSQL 8.4, so this function
-will likely throw an exception on earlier versions.
-
 If the `:description` argument is omitted, an appropriate description will be
 created. Examples:
 
@@ -7108,9 +7103,6 @@ available column privileges are:
 * REFERENCES
 * SELECT
 * UPDATE
-
-Note that column privileges were added in PostgreSQL 8.4, so this function
-will likely throw an exception on earlier versions.
 
 If the `:description` argument is omitted, an appropriate description will be
 created. Examples:
@@ -7308,9 +7300,6 @@ available function privileges are:
 
 * USAGE
 
-Note that foreign data wrapper privileges were added in PostgreSQL 8.4, so
-this function will likely throw an exception on earlier versions.
-
 If the `:description` argument is omitted, an appropriate description will be
 created. Examples:
 
@@ -7370,9 +7359,6 @@ Tests the privileges granted to a role to access a server. The available
 function privileges are:
 
 * USAGE
-
-Note that server privileges were added in PostgreSQL 8.4, so this function
-will likely throw an exception on earlier versions.
 
 If the `:description` argument is omitted, an appropriate description will be
 created. Examples:
@@ -7597,10 +7583,9 @@ Which would produce:
     # but yours is set to en_US.ISO8859-1.
     # As a result, some tests may fail. YMMV.
 
-You can pass data of any type to `diag()` on PostgreSQL 8.3 and higher and it
-will all be converted to text for the diagnostics. On PostgreSQL 8.4 and
-higher, you can pass any number of arguments (as long as they are all the same
-data type) and they will be concatenated together.
+You can pass data of any type to `diag()` and it will all be converted to text
+for the diagnostics. You can als pass any number of arguments (as long as they
+are all the same data type) and they will be concatenated together.
 
 Conditional Tests
 -----------------
@@ -7775,9 +7760,9 @@ the stringified version number displayed in the first part of the core
 `version()` function and stored in the "server_version" setting:
 
     try=% select current_setting( 'server_version'), pg_version();
-     current_setting | pg_version
+     current_setting | pg_version 
     -----------------+------------
-     8.3.4           | 8.3.4
+     12.2            | 12.2
     (1 row)
 
 ### `pg_version_num()` ###
@@ -7838,14 +7823,6 @@ when used in combination with `skip()`:
            skip('Collation-specific test', 4)
       END;
 
-On PostgreSQL 8.4 and higher, it can take any number of arguments. Lower than
-8.4 requires the explicit use of an array:
-
-    SELECT collect_tap(ARRAY[
-        ok(true, 'This should pass'),
-        ok(false, 'This should fail)
-    ]);
-
 ### `display_oper()` ###
 
     SELECT display_oper( :opername, :operoid );
@@ -7883,11 +7860,6 @@ executing the comparison, but might be generally useful.
      pg_typeof | pg_typeof
     -----------+-----------
      integer   | numeric
-
-*Note:* pgTAP does not build `pg_typeof()` on PostgreSQL 8.4 or higher,
-because it's in core in 8.4. You only need to worry about this if you depend
-on the function being in particular schema. It will always be in `pg_catalog`
-in 8.4 and higher.
 
 ### `findfuncs()` ###
 

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -3,7 +3,7 @@ pgTAP 1.1.0
 
 pgTAP is a unit testing framework for PostgreSQL written in PL/pgSQL and
 PL/SQL. It includes a comprehensive collection of
-[TAP](http://testanything.org)-emitting assertion functions, as well as the
+[TAP](https://testanything.org)-emitting assertion functions, as well as the
 ability to integrate with other TAP-emitting test frameworks. It can also be
 used in the xUnit testing style.
 
@@ -125,7 +125,7 @@ Testing pgTAP with pgTAP
 In addition to the PostgreSQL-standard `installcheck` target, the `test`
 target uses the `pg_prove` Perl program to do its testing, which will be
 installed with the
-[TAP::Parser::SourceHandler::pgTAP](http://search.cpan.org/dist/TAP-Parser-SourceHandler-pgTAP)
+[TAP::Parser::SourceHandler::pgTAP](https://metacpan.org/module/TAP::Parser::SourceHandler::pgTAP)
 CPAN distribution. You'll need to make sure that you use a database with
 PL/pgSQL loaded, or else the tests won't work. `pg_prove` supports a number of
 environment variables that you might need to use, including all the usual
@@ -239,7 +239,7 @@ Using `pg_prove`
 
 Or save yourself some effort -- and run a batch of tests scripts or all of
 your xUnit test functions at once -- by using `pg_prove`, available in the
-[TAP::Parser::SourceHandler::pgTAP](http://search.cpan.org/dist/TAP-Parser-SourceHandler-pgTAP)
+[TAP::Parser::SourceHandler::pgTAP](https://metacpan.org/module/TAP::Parser::SourceHandler::pgTAP)
 CPAN distribution. If you're not relying on `installcheck`, your test scripts
 can be a lot less verbose; you don't need to set all the extra variables,
 because `pg_prove` takes care of that for you:
@@ -772,7 +772,7 @@ an unnecessary PITA. Each of the query-executing functions in this section
 thus support an alternative to make your tests more SQLish: using prepared
 statements.
 
-[Prepared statements](http://www.postgresql.org/docs/current/static/sql-prepare.html)
+[Prepared statements](https://www.postgresql.org/docs/current/static/sql-prepare.html)
 allow you to just write SQL and simply
 pass the prepared statement names to test functions. For example, the above
 example can be rewritten as:
@@ -847,7 +847,7 @@ error-prone as you think they should be.
 : An SQL statement or the name of a prepared statement, passed as a string.
 
 `:errcode`
-: A [PostgreSQL error code](http://www.postgresql.org/docs/current/static/errcodes-appendix.html
+: A [PostgreSQL error code](https://www.postgresql.org/docs/current/static/errcodes-appendix.html
 "Appendix A. PostgreSQL Error Codes")
 
 `:errmsg`
@@ -869,9 +869,9 @@ five-character string (if it happens to consist only of numbers and you pass
 it as an integer, it will still work). If this value is not `NULL`,
 `throws_ok()` will check the thrown exception to ensure that it is the
 expected exception. For a complete list of error codes, see [Appendix
-A.](http://www.postgresql.org/docs/current/static/errcodes-appendix.html
+A.](https://www.postgresql.org/docs/current/static/errcodes-appendix.html
 "Appendix A. PostgreSQL Error Codes") in the [PostgreSQL
-documentation](http://www.postgresql.org/docs/current/static/).
+documentation](https://www.postgresql.org/docs/current/static/).
 
 The third argument is an error message. This will be most useful for functions
 you've written that raise exceptions, so that you can test the exception
@@ -1640,7 +1640,7 @@ test fails.
 : An SQL statement or the name of a prepared statement, passed as a string.
 
 `:record`
-: A row or value, also known as a [composite type](http://www.postgresql.org/docs/current/static/rowtypes.html).
+: A row or value, also known as a [composite type](https://www.postgresql.org/docs/current/static/rowtypes.html).
 
 `:description`
 : A short description of the test.
@@ -5591,7 +5591,7 @@ But then you check with `has_function()` first, right?
 
 Tests the volatility of a function. Supported volatilities are "volatile",
 "stable", and "immutable". Consult the [`CREATE FUNCTION`
-documentation](http://www.postgresql.org/docs/current/static/sql-createfunction.html)
+documentation](https://www.postgresql.org/docs/current/static/sql-createfunction.html)
 for details. The function name is required. If the `:schema` argument is
 omitted, then the function must be visible in the search path. If the
 `:args[]` argument is passed, then the function with that argument signature
@@ -5674,7 +5674,7 @@ other database objects.
 : A short description of the test.
 
 Tests that the specified procedural language is trusted. See the [CREATE
-LANGUAGE](http://www.postgresql.org/docs/current/static/sql-createlanguage.html
+LANGUAGE](https://www.postgresql.org/docs/current/static/sql-createlanguage.html
 "CREATE LANGUAGE") documentation for details on trusted and untrusted
 procedural languages. If the `:description` argument is not passed, a suitably
 useful default will be created.
@@ -5842,7 +5842,7 @@ varying", and not "VARCHAR".
 
 The The supported contexts are "implicit", "assignment", and "explicit". You
 can also just pass in "i", "a", or "e". Consult the PostgreSQL [`CREATE
-CAST`](http://www.postgresql.org/docs/current/static/sql-createcast.html)
+CAST`](https://www.postgresql.org/docs/current/static/sql-createcast.html)
 documentation for the differences between these contexts (hint: they
 correspond to the default context, `AS IMPLICIT`, and `AS ASSIGNMENT`). If you
 don't supply a test description, pgTAP will create a reasonable one for you.
@@ -5961,7 +5961,7 @@ members, don't you? Of course you do.
 
 Checks whether a rule on the specified relation is an `INSTEAD` rule. See the
 [`CREATE RULE`
-Documentation](http://www.postgresql.org/docs/current/static/sql-createrule.html)
+Documentation](https://www.postgresql.org/docs/current/static/sql-createrule.html)
 for details. If the `:schema` argument is omitted, the relation must be
 visible in the search path. If the `:description` argument is omitted, an
 appropriate description will be created. An example:
@@ -8327,7 +8327,7 @@ comments, suggestions, and bug reports are welcomed there.
 Author
 ------
 
-[David E. Wheeler](http://justatheory.com/)
+[David E. Wheeler](https://justatheory.com/)
 
 Credits
 -------

--- a/release.md
+++ b/release.md
@@ -90,7 +90,7 @@ Here are the steps to take to make a release of pgTAP:
          git ci -m 'Timestamp v0.98.0.'
          git tag -sm 'Tag v0.98.0.' v0.98.0
 
-*   Package the source and submit to [PGXN](http://manager.pgxn.org/).
+*   Package the source and submit to [PGXN](https://manager.pgxn.org/).
 
         gem install pgxn_utils
         git archive --format zip --prefix=pgtap-1.0.0/ \

--- a/release.md
+++ b/release.md
@@ -10,22 +10,20 @@ Here are the steps to take to make a release of pgTAP:
     [pull requests](https://github.com/theory/pgtap/pulls).
 
 *   Test on all supported PostgreSQL versions, starting with the latest version
-    (10) and moving backward in order (9.6, 9.5, 9.4, etc.).
+    (12) and moving backward in order (9.6, 9.5, 9.4, etc.).
     [pgenv](https://github.com/theory/pgenv/) is a handy tool for installing and
     switching between versions. For each version, ensure that:
 
     +   Patches apply cleanly (try to eliminate Hunk warnings for patches to
         `pgtap.sql` itself, usually by fixing line numbers)
 
-    +   All files are installed (on 8.3 and earlier that includes pgtap.so).
+    +   All files are installed.
 
-    +   `ALTER EXTENSION pgtap UPDATE;` works on 9.1 and higher.
+    +   `ALTER EXTENSION pgtap UPDATE;` works.
 
-    +   `CREATE EXTENSION pgtap;` works on 9.1 and higher.
+    +   `CREATE EXTENSION pgtap;` works.
 
-    +   All tests pass in `make installcheck` (on 8.1, move the pgtap source
-        dir into the postgres source `contrib` directory and run
-        `make NO_PGXS=1 installcheck`)
+    +   All tests pass in `make installcheck`.
 
 *   If you've made any significant changes while testing versions backward, test
     them again in forward order (9.1, 9.2, 9.3, etc.) to make sure the changes
@@ -41,11 +39,11 @@ Here are the steps to take to make a release of pgTAP:
     bullet mentioning the upgrade.
 
 *   Run `make html` (you'll need
-    [MultiMarkdown](http://fletcherpenney.net/multimarkdown/) (Macports: port
-    install multimarkdown) in your path and the
+    [MultiMarkdown](https://fletcherpenney.net/multimarkdown/) (Homebrew:
+    `brew install multimarkdown`) in your path and the
     [Pod::Simple::XHTML](https://metacpan.org/module/Pod::Simple::XHTML)
-    (Macports: port install p5-pod-simple) Perl module installed), then
-    checkout the `gh-pages` branch and make these changes:
+    (Homebrew: `brew install cpanm && cpanm Pod::Simple::XHTML`) Perl module
+    installed), then checkout the `gh-pages` branch and make these changes:
 
     +   `cp .documentation.html.template documentation.html`. Edit
         documentation.html, the main div should look like this:

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -3,7 +3,7 @@
 --
 -- The home page for the pgTAP project is:
 --
--- http://pgtap.org/
+-- https://pgtap.org/
 
 CREATE OR REPLACE FUNCTION pg_version()
 RETURNS text AS 'SELECT current_setting(''server_version'')'
@@ -1852,7 +1852,7 @@ RETURNS text AS $$
     ), $2);
 $$ LANGUAGE SQL immutable;
 
--- Borrowed from newsysviews: http://pgfoundry.org/projects/newsysviews/
+-- Borrowed from newsysviews: sFoundry/newsysviews/
 CREATE OR REPLACE FUNCTION _pg_sv_column_array( OID, SMALLINT[] )
 RETURNS NAME[] AS $$
     SELECT ARRAY(
@@ -1864,7 +1864,7 @@ RETURNS NAME[] AS $$
     )
 $$ LANGUAGE SQL stable;
 
--- Borrowed from newsysviews: http://pgfoundry.org/projects/newsysviews/
+-- Borrowed from newsysviews: https://www.postgresql.org/ftp/projects/pgFoundry/newsysviews/
 CREATE OR REPLACE FUNCTION _pg_sv_table_accessible( OID, OID )
 RETURNS BOOLEAN AS $$
     SELECT CASE WHEN has_schema_privilege($1, 'USAGE') THEN (
@@ -1879,7 +1879,7 @@ RETURNS BOOLEAN AS $$
     END;
 $$ LANGUAGE SQL immutable strict;
 
--- Borrowed from newsysviews: http://pgfoundry.org/projects/newsysviews/
+-- Borrowed from newsysviews: https://www.postgresql.org/ftp/projects/pgFoundry/newsysviews/
 CREATE OR REPLACE VIEW pg_all_foreign_keys
 AS
   SELECT n1.nspname                                   AS fk_schema_name,

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1852,7 +1852,7 @@ RETURNS text AS $$
     ), $2);
 $$ LANGUAGE SQL immutable;
 
--- Borrowed from newsysviews: sFoundry/newsysviews/
+-- Borrowed from newsysviews: https://www.postgresql.org/ftp/projects/pgFoundry/newsysviews/
 CREATE OR REPLACE FUNCTION _pg_sv_column_array( OID, SMALLINT[] )
 RETURNS NAME[] AS $$
     SELECT ARRAY(

--- a/test/sql/cmpok.sql
+++ b/test/sql/cmpok.sql
@@ -4,23 +4,6 @@
 SELECT plan(38);
 
 /****************************************************************************/
-
--- Set up some functions that are used only by this test, and aren't available
--- in PostgreSQL 8.2 or older
-
-CREATE OR REPLACE FUNCTION quote_literal(polygon)
-RETURNS TEXT AS 'SELECT '''''''' || textin(poly_out($1)) || '''''''''
-LANGUAGE SQL IMMUTABLE STRICT;
-
-CREATE OR REPLACE FUNCTION quote_literal(integer[])
-RETURNS TEXT AS 'SELECT '''''''' || textin(array_out($1)) || '''''''''
-LANGUAGE SQL IMMUTABLE STRICT;
-
-CREATE OR REPLACE FUNCTION quote_literal(inet[])
-RETURNS TEXT AS 'SELECT '''''''' || textin(array_out($1)) || '''''''''
-LANGUAGE SQL IMMUTABLE STRICT;
-
-/****************************************************************************/
 -- Test cmp_ok().
 SELECT * FROM check_test(
     cmp_ok( 1, '=', 1, '1 should = 1' ),

--- a/test/sql/coltap.sql
+++ b/test/sql/coltap.sql
@@ -516,117 +516,47 @@ SELECT * FROM check_test(
 );
 
 -- Make sure it works with a NULL default.
-CREATE OR REPLACE FUNCTION versiontests () RETURNS SETOF TEXT AS $$
-DECLARE
-    tap record;
-BEGIN
-    IF pg_version_num() < 80300 THEN
-        -- Before 8.3, have to cast to text.
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'myNum', 24::text ),
-            true,
-            'col_default_is( tab, col, int )',
-            'Column sometab."myNum" should default to ''24''',
-            ''
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+SELECT * FROM check_test(
+    col_default_is( 'sometab', 'myNum', 24 ),
+    true,
+    'col_default_is( tab, col, int )',
+    'Column sometab."myNum" should default to ''24''',
+    ''
+);
 
-        -- Before 8.3, DEFAULT NULL was ignored.
-        FOR tap IN SELECT * FROM fakeout(
-            true, 'col_default_is( tab, col, NULL, desc )'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+        -- We can handle DEFAULT NULL correctly.
+SELECT * FROM check_test(
+    col_default_is( 'sometab', 'numb', NULL::numeric, 'desc' ),
+    true,
+    'col_default_is( tab, col, NULL, desc )',
+    'desc',
+    ''
+);
 
-        FOR tap IN SELECT * FROM fakeout(
-            true, 'col_default_is( tab, col, NULL )'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+SELECT * FROM check_test(
+    col_default_is( 'sometab', 'numb', NULL::numeric ),
+    true,
+    'col_default_is( tab, col, NULL )',
+    'Column sometab.numb should default to NULL',
+    ''
+);
 
-        -- Make sure that it fails when there is no default.
-        -- Before 8.3, must cast values to text
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'plain', 1::text, 'desc' ),
-            false,
-            'col_default_is( tab, col, bogus, desc )',
-            'desc',
-            '    Column sometab.plain has no default'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+-- Make sure that it fails when there is no default.
+SELECT * FROM check_test(
+    col_default_is( 'sometab', 'plain', 1, 'desc' ),
+    false,
+    'col_default_is( tab, col, bogus, desc )',
+    'desc',
+    '    Column sometab.plain has no default'
+);
 
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'plain', 1::text ),
-            false,
-            'col_default_is( tab, col, bogus )',
-            'Column sometab.plain should default to ''1''',
-            '    Column sometab.plain has no default'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-    ELSE
-        -- In 8.3 and later, can just use the raw value.
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'myNum', 24 ),
-            true,
-            'col_default_is( tab, col, int )',
-            'Column sometab."myNum" should default to ''24''',
-            ''
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        -- In 8.3 and later, we can handle DEFAULT NULL correctly.
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'numb', NULL::numeric, 'desc' ),
-            true,
-            'col_default_is( tab, col, NULL, desc )',
-            'desc',
-            ''
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'numb', NULL::numeric ),
-            true,
-            'col_default_is( tab, col, NULL )',
-            'Column sometab.numb should default to NULL',
-            ''
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        -- Make sure that it fails when there is no default.
-        -- In 8.3 and later, can just use raw values.
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'plain', 1, 'desc' ),
-            false,
-            'col_default_is( tab, col, bogus, desc )',
-            'desc',
-            '    Column sometab.plain has no default'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        FOR tap IN SELECT * FROM check_test(
-            col_default_is( 'sometab', 'plain', 1 ),
-            false,
-            'col_default_is( tab, col, bogus )',
-            'Column sometab.plain should default to ''1''',
-            '    Column sometab.plain has no default'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-    END IF;
-    RETURN;
-END;
-$$ LANGUAGE plpgsql;
-SELECT * FROM versiontests();
+SELECT * FROM check_test(
+    col_default_is( 'sometab', 'plain', 1 ),
+    false,
+    'col_default_is( tab, col, bogus )',
+    'Column sometab.plain should default to ''1''',
+    '    Column sometab.plain has no default'
+);
 
 -- Make sure that it works when the default is an expression.
 SELECT * FROM check_test(

--- a/test/sql/istap.sql
+++ b/test/sql/istap.sql
@@ -61,89 +61,35 @@ CREATE TABLE mumble ( id int, name text );
 RESET client_min_messages;
 INSERT INTO mumble VALUES (1, 'hey');
 
-CREATE FUNCTION test_records() RETURNS SETOF TEXT AS $$
-DECLARE
-    tap record;
-BEGIN
-    IF pg_version_num() >= 80400 THEN
-        RETURN NEXT is( mumble.*, ROW(1, 'hey')::mumble, 'with records!' )
-          FROM mumble;
+SELECT is( mumble.*, ROW(1, 'hey')::mumble, 'with records!' )
+FROM mumble;
 
-        -- Before 8.3, have to cast to text.
-        FOR tap IN SELECT check_test(
-            is( mumble.*, ROW(1, 'HEY')::mumble ),
-            false,
-            'is(mumble, row) fail',
-            '',
-            '        have: (1,hey)
+SELECT check_test(
+    is( mumble.*, ROW(1, 'HEY')::mumble ),
+    false,
+    'is(mumble, row) fail',
+    '',
+    '        have: (1,hey)
         want: (1,HEY)'
-        ) AS b FROM mumble LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+) FROM mumble;
 
-        FOR tap IN SELECT check_test(
-            is( mumble.*, ROW(1, NULL)::mumble ),
-            false,
-            'is(mumble, row) fail with NULL',
-            '',
-            '        have: (1,hey)
+SELECT check_test(
+    is( mumble.*, ROW(1, NULL)::mumble ),
+    false,
+    'is(mumble, row) fail with NULL',
+    '',
+    '        have: (1,hey)
         want: (1,)'
-        ) AS b FROM mumble LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+) FROM mumble;
 
-        FOR tap IN SELECT check_test(
-            is( mumble.*, NULL::mumble ),
-            false,
-            'is(mumble, NULL)',
-            '',
-            '        have: (1,hey)
+SELECT check_test(
+    is( mumble.*, NULL::mumble ),
+    false,
+    'is(mumble, NULL)',
+    '',
+    '        have: (1,hey)
         want: NULL'
-        ) AS b FROM mumble LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-    ELSE
-        RETURN NEXT is( textin(record_out(mumble.*)), textin(record_out(ROW(1, 'hey'))), 'with records!' )
-          FROM mumble;
-
-        FOR tap IN SELECT check_test(
-            is( textin(record_out(mumble.*)), textin(record_out(ROW(1, 'HEY')))),
-            false,
-            'is(mumble, row) fail',
-            '',
-            '        have: (1,hey)
-        want: (1,HEY)'
-        ) AS b FROM mumble LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        FOR tap IN SELECT check_test(
-            is( textin(record_out(mumble.*)), textin(record_out(ROW(1, NULL))) ),
-            false,
-            'is(mumble, row) fail with NULL',
-            '',
-            '        have: (1,hey)
-        want: (1,)'
-        ) AS b FROM mumble LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        FOR tap IN SELECT check_test(
-            is( textin(record_out(mumble.*)), NULL::text ),
-            false,
-            'is(mumble, NULL)',
-            '',
-            '        have: (1,hey)
-        want: NULL'
-        ) AS b FROM mumble LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-    END IF;
-    RETURN;
-END;
-$$ LANGUAGE PLPGSQL;
-
-SELECT * FROM test_records();
+) FROM mumble;
 
 /****************************************************************************/
 -- Finish the tests and clean up.

--- a/test/sql/resultset.sql
+++ b/test/sql/resultset.sql
@@ -20,7 +20,7 @@ CREATE TABLE someat (
 
 RESET client_min_messages;
 
--- Top 100 boy an 100 girl names in 2005. http://www.ssa.gov/OACT/babynames/
+-- Top 100 boy an 100 girl names in 2005. https://www.ssa.gov/OACT/babynames/
 INSERT INTO names (name) VALUES ('Jacob');
 INSERT INTO names (name) VALUES ('Emily');
 INSERT INTO names (name) VALUES ('Michael');

--- a/test/sql/resultset.sql
+++ b/test/sql/resultset.sql
@@ -986,60 +986,27 @@ SELECT * FROM check_test(
         want: (foo,1)'
 );
 
--- Handle failure due to more subtle column mismatch, valid only on 8.4.
-CREATE OR REPLACE FUNCTION subtlefail() RETURNS SETOF TEXT AS $$
-DECLARE
-    tap record;
-BEGIN
-    IF pg_version_num() < 80400 THEN
-        -- 8.3 and earlier cast records to text, so subtlety is out.
-        -- Fake out pg_regress by running equivalent tests with fail().
-        FOR tap IN SELECT * FROM check_test(
-            fail('whatever'),
-            false,
-            'results_eq(values, values) subtle mismatch',
-            'whatever',
-            ''
-        ) AS a(b) LOOP RETURN NEXT tap.b; END LOOP;
+SELECT * FROM check_test(
+    results_eq(
+        'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
+        'VALUES (1, ''foo''), (2, ''bar'')'
+    ),
+    false,
+    'results_eq(values, values) subtle mismatch',
+    '',
+    '    Number of columns or their types differ between the queries'
+);
 
-        FOR tap IN SELECT * FROM check_test(
-            fail('whatever'),
-            false,
-            'results_eq(values, values) integer type mismatch',
-            'whatever',
-            ''
-        ) AS a(b) LOOP RETURN NEXT tap.b; END LOOP;
-
-    ELSE
-        -- 8.4 does true record comparisions, yay!
-        FOR tap IN SELECT * FROM check_test(
-            results_eq(
-                'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
-                'VALUES (1, ''foo''), (2, ''bar'')'
-            ),
-            false,
-            'results_eq(values, values) subtle mismatch',
-            '',
-            '    Number of columns or their types differ between the queries' ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-        FOR tap IN SELECT * FROM check_test(
-            results_eq(
-                'VALUES (1::int), (2::int)',
-                'VALUES (1::bigint), (2::bigint)'
-            ),
-            false,
-            'results_eq(values, values) integer type mismatch',
-            '',
-            '    Number of columns or their types differ between the queries' ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-    END IF;
-    RETURN;
-END;
-$$ LANGUAGE plpgsql;
-SELECT * FROM subtlefail();
+SELECT * FROM check_test(
+    results_eq(
+        'VALUES (1::int), (2::int)',
+        'VALUES (1::bigint), (2::bigint)'
+    ),
+    false,
+    'results_eq(values, values) integer type mismatch',
+    '',
+    '    Number of columns or their types differ between the queries'
+);
 
 -- Handle failure due to column count mismatch.
 SELECT * FROM check_test(
@@ -2162,71 +2129,41 @@ SELECT * FROM check_test(
     ''
 );
 
--- Handle failure due to more subtle column mismatch, valid only on 8.4.
-CREATE OR REPLACE FUNCTION subtlefail() RETURNS SETOF TEXT AS $$
-DECLARE
-    tap record;
-BEGIN
-    IF pg_version_num() < 80400 THEN
-        -- 8.3 and earlier cast records to text, so subtlety is out.
-        RETURN NEXT pass('results_ne(values, values) mismatch should fail');
-        RETURN NEXT pass('results_ne(values, values) mismatch should have the proper description');
-        RETURN NEXT pass('results_ne(values, values) mismatch should have the proper diagnostics');
-        RETURN NEXT pass('results_ne(values, values) subtle mismatch should fail');
-        RETURN NEXT pass('results_ne(values, values) subtle mismatch should have the proper description');
-        RETURN NEXT pass('results_ne(values, values) subtle mismatch should have the proper diagnostics');
-        RETURN NEXT pass('results_ne(values, values) fail column count should fail');
-        RETURN NEXT pass('results_ne(values, values) fail column count should have the proper description');
-        RETURN NEXT pass('results_ne(values, values) fail column count should have the proper diagnostics');
-    ELSE
-        -- 8.4 does true record comparisions, yay!
-        -- Handle failure due to column mismatch.
-        FOR tap IN SELECT * FROM check_test(
-            results_ne( 'VALUES (1, ''foo''), (2, ''bar'')', 'VALUES (''foo'', 1), (''bar'', 2)' ),
-            false,
-            'results_ne(values, values) mismatch',
-            '',
-            '    Columns differ between queries:
+-- Handle failure due to column mismatch.
+SELECT * FROM check_test(
+    results_ne( 'VALUES (1, ''foo''), (2, ''bar'')', 'VALUES (''foo'', 1), (''bar'', 2)' ),
+    false,
+    'results_ne(values, values) mismatch',
+    '',
+    '    Columns differ between queries:
         have: (1,foo)
         want: (foo,1)'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+);
 
-        -- Handle failure due to subtle column mismatch.
-        FOR tap IN SELECT * FROM check_test(
-            results_ne(
-                'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
-                'VALUES (1, ''foo''), (2, ''bar'')'
-            ),
-            false,
-            'results_ne(values, values) subtle mismatch',
-            '',
-            '    Columns differ between queries:
+-- Handle failure due to subtle column mismatch.
+SELECT * FROM check_test(
+    results_ne(
+        'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
+        'VALUES (1, ''foo''), (2, ''bar'')'
+    ),
+    false,
+    'results_ne(values, values) subtle mismatch',
+    '',
+    '    Columns differ between queries:
         have: (1,foo)
-        want: (1,foo)' ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+        want: (1,foo)'
+);
 
-        -- Handle failure due to column count mismatch.
-        FOR tap IN SELECT * FROM check_test(
-            results_ne( 'VALUES (1), (2)', 'VALUES (''foo'', 1), (''bar'', 2)' ),
-            false,
-            'results_ne(values, values) fail column count',
-            '',
-            '    Columns differ between queries:
+-- Handle failure due to column count mismatch.
+SELECT * FROM check_test(
+    results_ne( 'VALUES (1), (2)', 'VALUES (''foo'', 1), (''bar'', 2)' ),
+    false,
+    'results_ne(values, values) fail column count',
+    '',
+    '    Columns differ between queries:
         have: (1)
         want: (foo,1)'
-        )  AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-    END IF;
-    RETURN;
-END;
-$$ LANGUAGE plpgsql;
-SELECT * FROM subtlefail();
-
+);
 
 -- Compare with cursors.
 CLOSE cwant;

--- a/test/sql/todotap.sql
+++ b/test/sql/todotap.sql
@@ -96,8 +96,7 @@ SELECT * FROM check_test(
 \echo ok 26 - todo fail
 \echo ok 27 - todo fail
 SELECT * FROM todo('just because', 2 );
--- We have to use ok() instead of is() to get around lack of cast to text in 8.0.
-SELECT ok(
+SELECT is(
     ARRAY(
         SELECT fail('This is a todo test 1') AS stuff
         UNION
@@ -107,8 +106,8 @@ SELECT ok(
         UNION
         SELECT fail('This is a todo test 3')
         ORDER BY stuff
-    )
-    = ARRAY[
+    ),
+    ARRAY[
         'not ok 25 - This is a todo test 1 # TODO just because
 # Failed (TODO) test 25: "This is a todo test 1"',
         'not ok 26 - This is a todo test 2 # TODO inside
@@ -125,8 +124,7 @@ SELECT ok(
 \echo ok 30 - todo fail
 \echo ok 31 - todo fail
 SELECT * FROM todo_start('some todos');
--- We have to use ok() instead of is() to get around lack of cast to text in 8.0.
-SELECT ok(
+SELECT is(
     ARRAY(
         SELECT fail('This is a todo test 1') AS stuff
         UNION
@@ -142,8 +140,8 @@ SELECT ok(
         UNION
         SELECT in_todo()::text
         ORDER BY stuff
-    )
-    = ARRAY[
+    ),
+    ARRAY[
         'false',
         'not ok 29 - This is a todo test 1 # TODO some todos
 # Failed (TODO) test 29: "This is a todo test 1"',

--- a/test/sql/valueset.sql
+++ b/test/sql/valueset.sql
@@ -684,34 +684,17 @@ SELECT * FROM check_test(
         want: (foo,1)'
 );
 
--- Handle failure due to more subtle column mismatch, valid only on 8.4.
-CREATE OR REPLACE FUNCTION subtlefail() RETURNS SETOF TEXT AS $$
-DECLARE
-    tap record;
-BEGIN
-    IF pg_version_num() < 80400 THEN
-        -- 8.3 and earlier cast records to text, so subtlety is out.
-        RETURN NEXT pass('results_eq(values, values) subtle mismatch should fail');
-        RETURN NEXT pass('results_eq(values, values) subtle mismatch should have the proper description');
-        RETURN NEXT pass('results_eq(values, values) subtle mismatch should have the proper diagnostics');
-    ELSE
-        -- 8.4 does true record comparisions, yay!
-        FOR tap IN SELECT * FROM check_test(
-            results_eq(
-                'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
-                'VALUES (1, ''foo''), (2, ''bar'')'
-            ),
-            false,
-            'results_eq(values, values) subtle mismatch',
-            '',
-            '    Number of columns or their types differ between the queries' ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-    END IF;
-    RETURN;
-END;
-$$ LANGUAGE plpgsql;
-SELECT * FROM subtlefail();
+-- Handle failure due to more subtle column mismatch
+SELECT * FROM check_test(
+    results_eq(
+        'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
+        'VALUES (1, ''foo''), (2, ''bar'')'
+    ),
+    false,
+    'results_eq(values, values) subtle mismatch',
+    '',
+    '    Number of columns or their types differ between the queries'
+);
 
 -- Handle failure due to column count mismatch.
 SELECT * FROM check_test(
@@ -1526,71 +1509,41 @@ SELECT * FROM check_test(
     ''
 );
 
--- Handle failure due to more subtle column mismatch, valid only on 8.4.
-CREATE OR REPLACE FUNCTION subtlefail() RETURNS SETOF TEXT AS $$
-DECLARE
-    tap record;
-BEGIN
-    IF pg_version_num() < 80400 THEN
-        -- 8.3 and earlier cast records to text, so subtlety is out.
-        RETURN NEXT pass('results_ne(values, values) mismatch should fail');
-        RETURN NEXT pass('results_ne(values, values) mismatch should have the proper description');
-        RETURN NEXT pass('results_ne(values, values) mismatch should have the proper diagnostics');
-        RETURN NEXT pass('results_ne(values, values) subtle mismatch should fail');
-        RETURN NEXT pass('results_ne(values, values) subtle mismatch should have the proper description');
-        RETURN NEXT pass('results_ne(values, values) subtle mismatch should have the proper diagnostics');
-        RETURN NEXT pass('results_ne(values, values) fail column count should fail');
-        RETURN NEXT pass('results_ne(values, values) fail column count should have the proper description');
-        RETURN NEXT pass('results_ne(values, values) fail column count should have the proper diagnostics');
-    ELSE
-        -- 8.4 does true record comparisions, yay!
-        -- Handle failure due to column mismatch.
-        FOR tap IN SELECT * FROM check_test(
-            results_ne( 'VALUES (1, ''foo''), (2, ''bar'')', 'VALUES (''foo'', 1), (''bar'', 2)' ),
-            false,
-            'results_ne(values, values) mismatch',
-            '',
-            '    Columns differ between queries:
+-- Handle failure due to more subtle column mismatch.
+SELECT * FROM check_test(
+    results_ne( 'VALUES (1, ''foo''), (2, ''bar'')', 'VALUES (''foo'', 1), (''bar'', 2)' ),
+    false,
+    'results_ne(values, values) mismatch',
+    '',
+    '    Columns differ between queries:
         have: (1,foo)
         want: (foo,1)'
-        ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+);
 
-        -- Handle failure due to subtle column mismatch.
-        FOR tap IN SELECT * FROM check_test(
-            results_ne(
-                'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
-                'VALUES (1, ''foo''), (2, ''bar'')'
-            ),
-            false,
-            'results_ne(values, values) subtle mismatch',
-            '',
-            '    Columns differ between queries:
+-- Handle failure due to subtle column mismatch.
+SELECT * FROM check_test(
+    results_ne(
+        'VALUES (1, ''foo''::varchar), (2, ''bar''::varchar)',
+        'VALUES (1, ''foo''), (2, ''bar'')'
+    ),
+    false,
+    'results_ne(values, values) subtle mismatch',
+    '',
+    '    Columns differ between queries:
         have: (1,foo)
-        want: (1,foo)' ) AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
+        want: (1,foo)'
+);
 
-        -- Handle failure due to column count mismatch.
-        FOR tap IN SELECT * FROM check_test(
-            results_ne( 'VALUES (1), (2)', 'VALUES (''foo'', 1), (''bar'', 2)' ),
-            false,
-            'results_ne(values, values) fail column count',
-            '',
-            '    Columns differ between queries:
+-- Handle failure due to column count mismatch.
+SELECT * FROM check_test(
+    results_ne( 'VALUES (1), (2)', 'VALUES (''foo'', 1), (''bar'', 2)' ),
+    false,
+    'results_ne(values, values) fail column count',
+    '',
+    '    Columns differ between queries:
         have: (1)
         want: (foo,1)'
-        )  AS a(b) LOOP
-            RETURN NEXT tap.b;
-        END LOOP;
-
-    END IF;
-    RETURN;
-END;
-$$ LANGUAGE plpgsql;
-SELECT * FROM subtlefail();
-
+);
 
 -- Compare with cursors.
 CLOSE cwant;

--- a/test/sql/valueset.sql
+++ b/test/sql/valueset.sql
@@ -14,7 +14,7 @@ CREATE TABLE names (
 
 RESET client_min_messages;
 
--- Top 100 boy an 100 girl names in 2005. http://www.ssa.gov/OACT/babynames/
+-- Top 100 boy an 100 girl names in 2005. https://www.ssa.gov/OACT/babynames/
 INSERT INTO names (name) VALUES ('Jacob');
 INSERT INTO names (name) VALUES ('Emily');
 INSERT INTO names (name) VALUES ('Michael');

--- a/tools/pg-travis-test.sh
+++ b/tools/pg-travis-test.sh
@@ -139,7 +139,7 @@ fi
 
 sudo apt-get update
 
-# bug: http://www.postgresql.org/message-id/20130508192711.GA9243@msgid.df7cb.de
+# bug: https://www.postgresql.org/message-id/20130508192711.GA9243@msgid.df7cb.de
 sudo update-alternatives --remove-all postmaster.1.gz
 
 # stop all existing instances (because of https://github.com/travis-ci/travis-cookbooks/pull/221)


### PR DESCRIPTION
* Remove straggler references to versions of Postgres prior to 9.1, including in the README
* Update URLs to use https wherever possible (and fix some broken links)
* Update copyright date

Damn, @nasbyj, seems like we have a bunch of PRs to review if we want to do another release. Which we should probably consider soon.