### PR TITLE
Remove { DEFAULT | = } and default_expr in uninstall_pgtap.sql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ ifeq ($(shell echo $(VERSION) | grep -qE "^(9[.][012]|8[.][1234])" && echo yes |
 endif
 
 sql/uninstall_pgtap.sql: sql/pgtap.sql test/setup.sql
-	grep '^CREATE ' sql/pgtap.sql | $(PERL) -e 'for (reverse <STDIN>) { chomp; s/CREATE (OR REPLACE )?/DROP /; print "$$_;\n" }' | sed 's/DROP \(FUNCTION\|VIEW\|TYPE\) /DROP \1 IF EXISTS /' > sql/uninstall_pgtap.sql
+	grep '^CREATE ' sql/pgtap.sql | $(PERL) -e 'for (reverse <STDIN>) { chomp; s/CREATE (OR REPLACE )?/DROP /; print "$$_;\n" }' | sed 's/DROP \(FUNCTION\|VIEW\|TYPE\) /DROP \1 IF EXISTS /' | sed -E 's/ (DEFAULT|=)[ ]+[a-zA-Z0-9]+//g' > sql/uninstall_pgtap.sql
 
 #
 # Support for static install files


### PR DESCRIPTION
Previously the Makefile produced the DROP Function statements by
copying the function definitions verbatim, however DROP FUNCTION
does not recognize default values and will therefore error when
trying to drop a function that the install script created with
default values for some or all arguments