### PR TITLE
Debian deprecates `which`, use `command -v` instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 # We need to do various things with the PostgreSQL version.
 VERSION = $(shell $(PG_CONFIG) --version | awk '{print $$2}')
 $(info )
-$(info GNUmake running against Postgres version $(VERSION), with pg_config located at $(shell dirname `which "$(PG_CONFIG)"`))
+$(info GNUmake running against Postgres version $(VERSION), with pg_config located at $(shell dirname `command -v "$(PG_CONFIG)"`))
 $(info )
 
 #
@@ -163,10 +163,10 @@ endif
 
 # We need Perl.
 ifneq (,$(findstring missing,$(PERL)))
-PERL := $(shell which perl)
+PERL := $(shell command -v perl)
 else
 ifndef PERL
-PERL := $(shell which perl)
+PERL := $(shell command -v perl)
 endif
 endif
 

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -117,8 +117,8 @@ fi
 sudo=''
 if [ "$1" == '-s' ]; then
     # Useful error if we can't find sudo
-    which sudo > /dev/null
-    sudo=$(which sudo)
+    command -v sudo > /dev/null || echo "sudo not found"
+    sudo=$(command -v sudo)
     debug 2 "sudo located at $sudo"
     shift
 fi
@@ -150,7 +150,7 @@ exit_trap() {
     set +e
 
     # Force sudo on a debian system (see below)
-    [ -z "$ctl_separator" ] || sudo=$(which sudo)
+    [ -z "$ctl_separator" ] || sudo=$(command -v sudo)
 
     # Attempt to shut down any running clusters, otherwise we'll get log spew
     # when the temporary directories vanish.
@@ -166,7 +166,7 @@ exit_trap() {
 debug 5 "traps: $(trap -p)"
 
 cluster_name=test_pg_upgrade 
-if which pg_ctlcluster > /dev/null 2>&1; then
+if command -v pg_ctlcluster > /dev/null; then
     # Looks like we're running in a apt / Debian / Ubuntu environment, so use their tooling
     ctl_separator='--'
 

--- a/tools/getos.sh
+++ b/tools/getos.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-uname=`which uname`
-sed=`which sed`
-tr=`which tr`
+uname=`command -v uname`
+sed=`command -v sed`
+tr=`command -v tr`
 myuname=''
 newmyuname=''
 trnl=''

--- a/tools/util.sh
+++ b/tools/util.sh
@@ -158,7 +158,7 @@ err_report() {
 
 find_at_path() (
 export PATH="$1:$PATH" # Unfortunately need to maintain old PATH to be able to find `which` :(
-out=$(which $2)
+out=$(command -v $2)
 [ -n "$out" ] || die 2 "unable to find $2"
 echo $out
 )


### PR DESCRIPTION
debianutils (5.3-1) unstable; urgency=medium

  * The 'which' utility will be removed in the future.  Shell scripts
    often use it to check whether a command is available.  A more
    standard way to do this is with 'command -v'; for example:
      if command -v update-icon-caches >/dev/null; then
        update-icon-caches /usr/share/icons/...
      fi
    '2>/dev/null' is unnecessary when using 'command': POSIX says "no
    output shall be written" if the command isn't found.  It's also
    unnecessary for the debianutils version of 'which', and hides the
    deprecation warning.

 -- Clint Adams <clint@debian.org>  Fri, 20 Aug 2021 07:22:18 -0400