### PR TITLE
Add function type testing

### DIFF
--- a/Changes
+++ b/Changes
@@ -150,7 +150,18 @@ Revision history for pgTAP
     + `partitions_are()`
 * Added the materialized view-testing assertion functions to the v0.95.0 upgrade
   script; they were inadvertently omitted in the v0.95.0 release.
-* Fixed faling tests on Postgres 8.1.
+* Fixed failing tests on Postgres 8.1.
+* Added function type testing functions to complement `is_aggregate()` and
+  `isnt_aggregate()`:
+    + `is_normal_function()`
+    + `isnt_normal_function()`
+    + `is_window()`
+    + `isnt_window()`
+    + `is_procedure()`
+    + `isnt_procedure()`
+* Made the diagnostic output of `is_aggregate()` and `isnt_aggregate()`
+  consistent. Previously, when the function did not exist, some instances would
+  generate diagnostic output and some would not.
 
 0.97.0 2016-11-28T22:18:29Z
 ---------------------------

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,11 @@ ifeq ($(shell echo $(VERSION) | grep -qE "^[89][.]" && echo yes || echo no),yes)
 EXCLUDE_TEST_FILES += test/sql/partitions.sql
 endif
 
+# Stored procecures not supported prior to Postgres 11.
+ifeq ($(shell echo $(VERSION) | grep -qE "^([89]|10)[.]" && echo yes || echo no),yes)
+EXCLUDE_TEST_FILES += test/sql/proctap.sql
+endif
+
 #
 # Check for missing extensions
 #
@@ -399,7 +404,6 @@ $(TB_DIR)/parallel.sch: $(GENERATED_SCHEDULE_DEPS)
 
 $(TB_DIR)/run.sch: $(TB_DIR)/which_schedule $(GENERATED_SCHEDULES)
 	cp `cat $<` $@
-
 
 # Don't generate noise if we're not running tests...
 .PHONY: extension_check

--- a/compat/gencore
+++ b/compat/gencore
@@ -5,9 +5,8 @@ use warnings;
 
 my $invert = shift;
 my %keep = map { chomp; $_ => 1 } <DATA>;
-
-
 my ($name, $type) = $invert ? ('Schema', 'schema-testing') : ('Core', 'assertion');
+
 print qq{
 -- This file defines pgTAP $name, a portable collection of $type
 -- functions for TAP-based unit testing on PostgreSQL 9.1 or higher. It is
@@ -83,6 +82,7 @@ throws_ok
 lives_ok
 performs_ok
 performs_within
+_time_trial_type
 _time_trials
 _ident_array_to_string
 _prokind
@@ -128,8 +128,16 @@ _returns
 function_returns
 _definer
 is_definer
-_agg
+isnt_definer
+_type_func
 is_aggregate
+isnt_aggregate
+is_normal_function
+isnt_normal_function
+is_window
+isnt_window
+is_procedure
+isnt_procedure
 _strict
 is_strict
 isnt_strict
@@ -174,3 +182,5 @@ _get_dtype
 domain_type_is
 domain_type_isnt
 row_eq
+_error_diag
+

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -5609,6 +5609,87 @@ If the function does not exist, a handy diagnostic message will let you know:
 
 But then you check with `has_function()` first, right?
 
+### `is_normal_function()` ###
+
+    SELECT is_normal_function( :schema, :function, :args, :description );
+    SELECT is_normal_function( :schema, :function, :args );
+    SELECT is_normal_function( :schema, :function, :description );
+    SELECT is_normal_function( :schema, :function );
+    SELECT is_normal_function( :function, :args, :description );
+    SELECT is_normal_function( :function, :args );
+    SELECT is_normal_function( :function, :description );
+    SELECT is_normal_function( :function );
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the function.
+
+`:function`
+: Function name.
+
+`:args`
+: Array of data types for the function arguments.
+
+`:description`
+: A short description of the test.
+
+Tests that a function is a normal function --- that is, not an aggregate,
+window, or procedural function. If the `:schema` argument is omitted, then the
+function must be visible in the search path. If the `:args[]` argument is
+passed, then the function with that argument signature will be the one tested;
+otherwise, a function with any signature will be checked (pass an empty array to
+specify a function with an empty signature). If the `:description` is omitted, a
+reasonable substitute will be created. Fails if the function is not a normal
+function or if the function does not exist. Examples:
+
+    SELECT is_normal_function( 'myschema', 'foo',  ARRAY['integer', 'text'] );
+    SELECT is_normal_function( 'do_something' );
+    SELECT is_normal_function( 'do_something', ARRAY['integer'] );
+    SELECT is_normal_function( 'do_something', ARRAY['numeric'] );
+
+If no such function exists, a handy diagnostic message will let you know:
+
+    # Failed test 290: "Function nasty() should be a normal function"
+    #     Function nasty() does not exist
+
+But then you check with `has_function()` first, right?
+
+### `isnt_normal_function()` ###
+
+    SELECT isnt_normal_function( :schema, :function, :args, :description );
+    SELECT isnt_normal_function( :schema, :function, :args );
+    SELECT isnt_normal_function( :schema, :function, :description );
+    SELECT isnt_normal_function( :schema, :function );
+    SELECT isnt_normal_function( :function, :args, :description );
+    SELECT isnt_normal_function( :function, :args );
+    SELECT isnt_normal_function( :function, :description );
+    SELECT isnt_normal_function( :function );
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the function.
+
+`:function`
+: Function name.
+
+`:args`
+: Array of data types for the function arguments.
+
+`:description`
+: A short description of the test.
+
+This function is the inverse of `is_normal_function()`. The test passes if the
+specified function exists and is not a normal function.
+
+If no such function exists, a handy diagnostic message will let you know:
+
+    # Failed test 290: "Function nasty() should not be a normal function"
+    #     Function nasty() does not exist
+
+But then you check with `has_function()` first, right?
+
 ### `is_aggregate()` ###
 
     SELECT is_aggregate( :schema, :function, :args, :description );
@@ -5635,11 +5716,12 @@ But then you check with `has_function()` first, right?
 : A short description of the test.
 
 Tests that a function is an aggregate function. If the `:schema` argument is
-omitted, then the function must be visible in the search path. If the
-`:args[]` argument is passed, then the function with that argument signature
-will be the one tested; otherwise, a function with any signature will be
-checked (pass an empty array to specify a function with an empty signature).
-If the `:description` is omitted, a reasonable substitute will be created.
+omitted, then the function must be visible in the search path. If the `:args[]`
+argument is passed, then the function with that argument signature will be the
+one tested; otherwise, a function with any signature will be checked (pass an
+empty array to specify a function with an empty signature). If the
+`:description` is omitted, a reasonable substitute will be created. Fails if the
+function is not an aggregate function, or if the function does not exist.
 Examples:
 
     SELECT is_aggregate( 'myschema', 'foo',  ARRAY['integer', 'text'] );
@@ -5647,7 +5729,7 @@ Examples:
     SELECT is_aggregate( 'do_something', ARRAY['integer'] );
     SELECT is_aggregate( 'do_something', ARRAY['numeric'] );
 
-If the function does not exist, a handy diagnostic message will let you know:
+If no such function exists, a handy diagnostic message will let you know:
 
     # Failed test 290: "Function nasty() should be an aggregate function"
     #     Function nasty() does not exist
@@ -5679,12 +5761,172 @@ But then you check with `has_function()` first, right?
 `:description`
 : A short description of the test.
 
-This function is the inverse of `is_aggregate()`. The test passes if the specified
-function is not an aggregate function.
+This function is the inverse of `is_aggregate()`. The test passes if the
+specified function exists and is not an aggregate function.
 
-If the function does not exist, a handy diagnostic message will let you know:
+If no such function exists, a handy diagnostic message will let you know:
 
     # Failed test 290: "Function nasty() should not be an aggregate function"
+    #     Function nasty() does not exist
+
+But then you check with `has_function()` first, right?
+
+### `is_window()` ###
+
+    SELECT is_window( :schema, :function, :args, :description );
+    SELECT is_window( :schema, :function, :args );
+    SELECT is_window( :schema, :function, :description );
+    SELECT is_window( :schema, :function );
+    SELECT is_window( :function, :args, :description );
+    SELECT is_window( :function, :args );
+    SELECT is_window( :function, :description );
+    SELECT is_window( :function );
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the function.
+
+`:function`
+: Function name.
+
+`:args`
+: Array of data types for the function arguments.
+
+`:description`
+: A short description of the test.
+
+Tests that a function is a window function. If the `:schema` argument is
+omitted, then the function must be visible in the search path. If the `:args[]`
+argument is passed, then the function with that argument signature will be the
+one tested; otherwise, a function with any signature will be checked (pass an
+empty array to specify a function with an empty signature). If the
+`:description` is omitted, a reasonable substitute will be created. Fails if the
+function is not a window function or if the function does not exist. Examples:
+
+    SELECT is_window( 'myschema', 'foo',  ARRAY['integer', 'text'] );
+    SELECT is_window( 'do_something' );
+    SELECT is_window( 'do_something', ARRAY['integer'] );
+    SELECT is_window( 'do_something', ARRAY['numeric'] );
+
+If no such function exists, a handy diagnostic message will let you know:
+
+    # Failed test 290: "Function nasty() should be a window function"
+    #     Function nasty() does not exist
+
+But then you check with `has_function()` first, right?
+
+### `isnt_window()` ###
+
+    SELECT isnt_window( :schema, :function, :args, :description );
+    SELECT isnt_window( :schema, :function, :args );
+    SELECT isnt_window( :schema, :function, :description );
+    SELECT isnt_window( :schema, :function );
+    SELECT isnt_window( :function, :args, :description );
+    SELECT isnt_window( :function, :args );
+    SELECT isnt_window( :function, :description );
+    SELECT isnt_window( :function );
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the function.
+
+`:function`
+: Function name.
+
+`:args`
+: Array of data types for the function arguments.
+
+`:description`
+: A short description of the test.
+
+This function is the inverse of `is_window()`. The test passes if the
+specified function exists and is not a window function.
+
+If no such function exists, a handy diagnostic message will let you know:
+
+    # Failed test 290: "Function nasty() should not be a window function"
+    #     Function nasty() does not exist
+
+But then you check with `has_function()` first, right?
+
+### `is_procedure()` ###
+
+    SELECT is_procedure( :schema, :function, :args, :description );
+    SELECT is_procedure( :schema, :function, :args );
+    SELECT is_procedure( :schema, :function, :description );
+    SELECT is_procedure( :schema, :function );
+    SELECT is_procedure( :function, :args, :description );
+    SELECT is_procedure( :function, :args );
+    SELECT is_procedure( :function, :description );
+    SELECT is_procedure( :function );
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the function.
+
+`:function`
+: Function name.
+
+`:args`
+: Array of data types for the function arguments.
+
+`:description`
+: A short description of the test.
+
+Tests that a function is a procedural function. If the `:schema` argument is
+omitted, then the function must be visible in the search path. If the `:args[]`
+argument is passed, then the function with that argument signature will be the
+one tested; otherwise, a function with any signature will be checked (pass an
+empty array to specify a function with an empty signature). If the
+`:description` is omitted, a reasonable substitute will be created. Fails if the
+function is not a procedure or if the function does not exist. Examples:
+
+    SELECT is_procedure( 'myschema', 'foo',  ARRAY['integer', 'text'] );
+    SELECT is_procedure( 'do_something' );
+    SELECT is_procedure( 'do_something', ARRAY['integer'] );
+    SELECT is_procedure( 'do_something', ARRAY['numeric'] );
+
+If no such function exists, a handy diagnostic message will let you know:
+
+    # Failed test 290: "Function nasty() should be a procedure"
+    #     Function nasty() does not exist
+
+But then you check with `has_function()` first, right?
+
+### `isnt_procedure()` ###
+
+    SELECT isnt_procedure( :schema, :function, :args, :description );
+    SELECT isnt_procedure( :schema, :function, :args );
+    SELECT isnt_procedure( :schema, :function, :description );
+    SELECT isnt_procedure( :schema, :function );
+    SELECT isnt_procedure( :function, :args, :description );
+    SELECT isnt_procedure( :function, :args );
+    SELECT isnt_procedure( :function, :description );
+    SELECT isnt_procedure( :function );
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the function.
+
+`:function`
+: Function name.
+
+`:args`
+: Array of data types for the function arguments.
+
+`:description`
+: A short description of the test.
+
+This function is the inverse of `is_procedure()`. The test passes if the
+specified function exists and is not a procedure.
+
+If no such function exists, a handy diagnostic message will let you know:
+
+    # Failed test 290: "Function nasty() should not be a procedure"
     #     Function nasty() does not exist
 
 But then you check with `has_function()` first, right?

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -5893,6 +5893,11 @@ RETURNS TEXT AS $$
     SELECT ok( NOT _definer($1), 'Function ' || quote_ident($1) || '() should not be security definer' );
 $$ LANGUAGE sql;
 
+-- Returns true if the specified function exists and is the specified type,
+-- false if it exists and is not the specified type, and NULL if it does not
+-- exist. Types are f for a normal function, p for a procedure, a for an
+-- aggregate function, or w for a window function
+-- _type_func(type, schema, function, args[])
 CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME, NAME[] )
 RETURNS BOOLEAN AS $$
     SELECT kind = $1
@@ -5902,11 +5907,13 @@ RETURNS BOOLEAN AS $$
        AND args   = array_to_string($4, ',')
 $$ LANGUAGE SQL;
 
+-- _type_func(type, schema, function)
 CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME )
 RETURNS BOOLEAN AS $$
     SELECT kind = $1 FROM tap_funky WHERE schema = $2 AND name = $3
 $$ LANGUAGE SQL;
 
+-- _type_func(type, function, args[])
 CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME[] )
 RETURNS BOOLEAN AS $$
     SELECT kind = $1
@@ -5916,6 +5923,7 @@ RETURNS BOOLEAN AS $$
        AND is_visible;
 $$ LANGUAGE SQL;
 
+-- _type_func(type, function)
 CREATE OR REPLACE FUNCTION _type_func ( "char", NAME )
 RETURNS BOOLEAN AS $$
     SELECT kind = $1 FROM tap_funky WHERE name = $2 AND is_visible;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1073,9 +1073,10 @@ $$ LANGUAGE SQL;
 -- has_view( schema, view )
 CREATE OR REPLACE FUNCTION has_view ( NAME, NAME )
 RETURNS TEXT AS $$
-    SELECT has_view ($1, $2, 
-    'View ' || quote_ident($1) || '.' || quote_ident($2) || ' should exist'
-    );    
+    SELECT has_view (
+        $1, $2,
+        'View ' || quote_ident($1) || '.' || quote_ident($2) || ' should exist'
+    );
 $$ LANGUAGE SQL;
 
 -- has_view( view, description )
@@ -2517,12 +2518,11 @@ BEGIN
     IF pg_version_num() >= 110000 THEN
         RETURN prokind FROM pg_catalog.pg_proc WHERE oid = p_oid;
     ELSE
-        RETURN CASE proisagg WHEN true THEN 'a' WHEN false THEN 'f' END
+        RETURN CASE WHEN proisagg THEN 'a' WHEN proiswindow THEN 'w' ELSE 'f' END
             FROM pg_catalog.pg_proc WHERE oid = p_oid;
     END IF;
 END;
 $$ LANGUAGE plpgsql STABLE;
-
 
 CREATE OR REPLACE VIEW tap_funky
  AS SELECT p.oid         AS oid,
@@ -5893,45 +5893,45 @@ RETURNS TEXT AS $$
     SELECT ok( NOT _definer($1), 'Function ' || quote_ident($1) || '() should not be security definer' );
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION _agg ( NAME, NAME, NAME[] )
+CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME, NAME[] )
 RETURNS BOOLEAN AS $$
-    SELECT kind = 'a'
+    SELECT kind = $1
       FROM tap_funky
-     WHERE schema = $1
-       AND name   = $2
-       AND args   = array_to_string($3, ',')
+     WHERE schema = $2
+       AND name   = $3
+       AND args   = array_to_string($4, ',')
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION _agg ( NAME, NAME )
+CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME )
 RETURNS BOOLEAN AS $$
-    SELECT kind = 'a' FROM tap_funky WHERE schema = $1 AND name = $2
+    SELECT kind = $1 FROM tap_funky WHERE schema = $2 AND name = $3
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION _agg ( NAME, NAME[] )
+CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME[] )
 RETURNS BOOLEAN AS $$
-    SELECT kind = 'a'
+    SELECT kind = $1
       FROM tap_funky
-     WHERE name = $1
-       AND args = array_to_string($2, ',')
+     WHERE name = $2
+       AND args = array_to_string($3, ',')
        AND is_visible;
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION _agg ( NAME )
+CREATE OR REPLACE FUNCTION _type_func ( "char", NAME )
 RETURNS BOOLEAN AS $$
-    SELECT kind = 'a' FROM tap_funky WHERE name = $1 AND is_visible;
+    SELECT kind = $1 FROM tap_funky WHERE name = $2 AND is_visible;
 $$ LANGUAGE SQL;
 
 -- is_aggregate( schema, function, args[], description )
 CREATE OR REPLACE FUNCTION is_aggregate ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare($1, $2, $3, _agg($1, $2, $3), $4 );
+    SELECT _func_compare($1, $2, $3, _type_func( 'a', $1, $2, $3), $4 );
 $$ LANGUAGE SQL;
 
 -- is_aggregate( schema, function, args[] )
 CREATE OR REPLACE FUNCTION is_aggregate( NAME, NAME, NAME[] )
 RETURNS TEXT AS $$
-    SELECT ok(
-        _agg($1, $2, $3),
+    SELECT _func_compare(
+        $1, $2, $3, _type_func('a', $1, $2, $3),
         'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
         array_to_string($3, ', ') || ') should be an aggregate function'
     );
@@ -5940,14 +5940,14 @@ $$ LANGUAGE sql;
 -- is_aggregate( schema, function, description )
 CREATE OR REPLACE FUNCTION is_aggregate ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare($1, $2, _agg($1, $2), $3 );
+    SELECT _func_compare($1, $2, _type_func('a', $1, $2), $3 );
 $$ LANGUAGE SQL;
 
 -- is_aggregate( schema, function )
 CREATE OR REPLACE FUNCTION is_aggregate( NAME, NAME )
 RETURNS TEXT AS $$
-    SELECT ok(
-        _agg($1, $2),
+    SELECT _func_compare(
+        $1, $2, _type_func('a', $1, $2),
         'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should be an aggregate function'
     );
 $$ LANGUAGE sql;
@@ -5955,14 +5955,14 @@ $$ LANGUAGE sql;
 -- is_aggregate( function, args[], description )
 CREATE OR REPLACE FUNCTION is_aggregate ( NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare(NULL, $1, $2, _agg($1, $2), $3 );
+    SELECT _func_compare( NULL, $1, $2, _type_func('a', $1, $2), $3 );
 $$ LANGUAGE SQL;
 
 -- is_aggregate( function, args[] )
 CREATE OR REPLACE FUNCTION is_aggregate( NAME, NAME[] )
 RETURNS TEXT AS $$
-    SELECT ok(
-        _agg($1, $2),
+    SELECT _func_compare(
+        NULL, $1, $2, _type_func('a', $1, $2),
         'Function ' || quote_ident($1) || '(' ||
         array_to_string($2, ', ') || ') should be an aggregate function'
     );
@@ -5971,26 +5971,29 @@ $$ LANGUAGE sql;
 -- is_aggregate( function, description )
 CREATE OR REPLACE FUNCTION is_aggregate( NAME, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare(NULL, $1, _agg($1), $2 );
+    SELECT _func_compare(NULL, $1, _type_func('a', $1), $2 );
 $$ LANGUAGE sql;
 
 -- is_aggregate( function )
 CREATE OR REPLACE FUNCTION is_aggregate( NAME )
 RETURNS TEXT AS $$
-    SELECT ok( _agg($1), 'Function ' || quote_ident($1) || '() should be an aggregate function' );
+    SELECT _func_compare(
+        NULL, $1,  _type_func('a', $1),
+        'Function ' || quote_ident($1) || '() should be an aggregate function'
+    );
 $$ LANGUAGE sql;
 
 -- isnt_aggregate( schema, function, args[], description )
 CREATE OR REPLACE FUNCTION isnt_aggregate ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare($1, $2, $3, NOT _agg($1, $2, $3), $4 );
+    SELECT _func_compare($1, $2, $3, NOT _type_func('a', $1, $2, $3), $4 );
 $$ LANGUAGE SQL;
 
 -- isnt_aggregate( schema, function, args[] )
 CREATE OR REPLACE FUNCTION isnt_aggregate( NAME, NAME, NAME[] )
 RETURNS TEXT AS $$
-    SELECT ok(
-        NOT _agg($1, $2, $3),
+    SELECT _func_compare(
+        $1, $2, $3, NOT _type_func('a', $1, $2, $3),
         'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
         array_to_string($3, ', ') || ') should not be an aggregate function'
     );
@@ -5999,14 +6002,14 @@ $$ LANGUAGE sql;
 -- isnt_aggregate( schema, function, description )
 CREATE OR REPLACE FUNCTION isnt_aggregate ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare($1, $2, NOT _agg($1, $2), $3 );
+    SELECT _func_compare($1, $2, NOT _type_func('a', $1, $2), $3 );
 $$ LANGUAGE SQL;
 
 -- isnt_aggregate( schema, function )
 CREATE OR REPLACE FUNCTION isnt_aggregate( NAME, NAME )
 RETURNS TEXT AS $$
-    SELECT ok(
-        NOT _agg($1, $2),
+    SELECT _func_compare(
+        $1, $2, NOT _type_func('a', $1, $2),
         'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should not be an aggregate function'
     );
 $$ LANGUAGE sql;
@@ -6014,14 +6017,14 @@ $$ LANGUAGE sql;
 -- isnt_aggregate( function, args[], description )
 CREATE OR REPLACE FUNCTION isnt_aggregate ( NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare(NULL, $1, $2, NOT _agg($1, $2), $3 );
+    SELECT _func_compare(NULL, $1, $2, NOT _type_func('a', $1, $2), $3 );
 $$ LANGUAGE SQL;
 
 -- isnt_aggregate( function, args[] )
 CREATE OR REPLACE FUNCTION isnt_aggregate( NAME, NAME[] )
 RETURNS TEXT AS $$
-    SELECT ok(
-        NOT _agg($1, $2),
+    SELECT _func_compare(
+        NULL, $1, $2, NOT _type_func('a', $1, $2),
         'Function ' || quote_ident($1) || '(' ||
         array_to_string($2, ', ') || ') should not be an aggregate function'
     );
@@ -6030,13 +6033,16 @@ $$ LANGUAGE sql;
 -- isnt_aggregate( function, description )
 CREATE OR REPLACE FUNCTION isnt_aggregate( NAME, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare(NULL, $1, NOT _agg($1), $2 );
+    SELECT _func_compare(NULL, $1, NOT _type_func('a', $1), $2 );
 $$ LANGUAGE sql;
 
 -- isnt_aggregate( function )
 CREATE OR REPLACE FUNCTION isnt_aggregate( NAME )
 RETURNS TEXT AS $$
-    SELECT ok( NOT _agg($1), 'Function ' || quote_ident($1) || '() should not be an aggregate function' );
+    SELECT _func_compare(
+        NULL, $1, NOT _type_func('a', $1),
+        'Function ' || quote_ident($1) || '() should not be an aggregate function'
+    );
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION _strict ( NAME, NAME, NAME[] )
@@ -10966,3 +10972,377 @@ RETURNS TEXT AS $$
         'Table ' || quote_ident( $1 ) || ' should not be a descendent of ' || quote_ident( $2)
     );
 $$ LANGUAGE SQL;
+
+-- is_normal_function( schema, function, args[], description )
+CREATE OR REPLACE FUNCTION is_normal_function ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, $3, _type_func('f', $1, $2, $3), $4 );
+$$ LANGUAGE SQL;
+
+-- is_normal_function( schema, function, args[] )
+CREATE OR REPLACE FUNCTION is_normal_function( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, $3,
+        _type_func('f', $1, $2, $3),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
+        array_to_string($3, ', ') || ') should be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- is_normal_function( schema, function, description )
+CREATE OR REPLACE FUNCTION is_normal_function ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, _type_func('f', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- is_normal_function( schema, function )
+CREATE OR REPLACE FUNCTION is_normal_function( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, _type_func('f', $1, $2),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- is_normal_function( function, args[], description )
+CREATE OR REPLACE FUNCTION is_normal_function ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, $2, _type_func('f', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- is_normal_function( function, args[] )
+CREATE OR REPLACE FUNCTION is_normal_function( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, $2, _type_func('f', $1, $2),
+        'Function ' || quote_ident($1) || '(' ||
+        array_to_string($2, ', ') || ') should be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- is_normal_function( function, description )
+CREATE OR REPLACE FUNCTION is_normal_function( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, _type_func('f', $1), $2 );
+$$ LANGUAGE sql;
+
+-- is_normal_function( function )
+CREATE OR REPLACE FUNCTION is_normal_function( NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, _type_func('f', $1),
+        'Function ' || quote_ident($1) || '() should be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_normal_function( schema, function, args[], description )
+CREATE OR REPLACE FUNCTION isnt_normal_function ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, $3, NOT _type_func('f', $1, $2, $3), $4 );
+$$ LANGUAGE SQL;
+
+-- isnt_normal_function( schema, function, args[] )
+CREATE OR REPLACE FUNCTION isnt_normal_function( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, $3, NOT _type_func('f', $1, $2, $3),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
+        array_to_string($3, ', ') || ') should not be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_normal_function( schema, function, description )
+CREATE OR REPLACE FUNCTION isnt_normal_function ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, NOT _type_func('f', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- isnt_normal_function( schema, function )
+CREATE OR REPLACE FUNCTION isnt_normal_function( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, NOT _type_func('f', $1, $2),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should not be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_normal_function( function, args[], description )
+CREATE OR REPLACE FUNCTION isnt_normal_function ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, $2, NOT _type_func('f', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- isnt_normal_function( function, args[] )
+CREATE OR REPLACE FUNCTION isnt_normal_function( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, $2,
+        NOT _type_func('f', $1, $2),
+        'Function ' || quote_ident($1) || '(' ||
+        array_to_string($2, ', ') || ') should not be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_normal_function( function, description )
+CREATE OR REPLACE FUNCTION isnt_normal_function( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, NOT _type_func('f', $1), $2 );
+$$ LANGUAGE sql;
+
+-- isnt_normal_function( function )
+CREATE OR REPLACE FUNCTION isnt_normal_function( NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, NOT _type_func('f', $1),
+        'Function ' || quote_ident($1) || '() should not be a normal function'
+    );
+$$ LANGUAGE sql;
+
+-- is_window( schema, function, args[], description )
+CREATE OR REPLACE FUNCTION is_window ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, $3, _type_func( 'w', $1, $2, $3), $4 );
+$$ LANGUAGE SQL;
+
+-- is_window( schema, function, args[] )
+CREATE OR REPLACE FUNCTION is_window( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, $3, _type_func('w', $1, $2, $3),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
+        array_to_string($3, ', ') || ') should be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- is_window( schema, function, description )
+CREATE OR REPLACE FUNCTION is_window ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, _type_func('w', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- is_window( schema, function )
+CREATE OR REPLACE FUNCTION is_window( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, _type_func('w', $1, $2),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- is_window( function, args[], description )
+CREATE OR REPLACE FUNCTION is_window ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, $2, _type_func('w', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- is_window( function, args[] )
+CREATE OR REPLACE FUNCTION is_window( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, $2, _type_func('w', $1, $2),
+        'Function ' || quote_ident($1) || '(' ||
+        array_to_string($2, ', ') || ') should be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- is_window( function, description )
+CREATE OR REPLACE FUNCTION is_window( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, _type_func('w', $1), $2 );
+$$ LANGUAGE sql;
+
+-- is_window( function )
+CREATE OR REPLACE FUNCTION is_window( NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, _type_func('w', $1),
+        'Function ' || quote_ident($1) || '() should be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_window( schema, function, args[], description )
+CREATE OR REPLACE FUNCTION isnt_window ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, $3, NOT _type_func('w', $1, $2, $3), $4 );
+$$ LANGUAGE SQL;
+
+-- isnt_window( schema, function, args[] )
+CREATE OR REPLACE FUNCTION isnt_window( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, $3, NOT _type_func('w', $1, $2, $3),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
+        array_to_string($3, ', ') || ') should not be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_window( schema, function, description )
+CREATE OR REPLACE FUNCTION isnt_window ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, NOT _type_func('w', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- isnt_window( schema, function )
+CREATE OR REPLACE FUNCTION isnt_window( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, NOT _type_func('w', $1, $2),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should not be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_window( function, args[], description )
+CREATE OR REPLACE FUNCTION isnt_window ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, $2, NOT _type_func('w', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- isnt_window( function, args[] )
+CREATE OR REPLACE FUNCTION isnt_window( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, $2, NOT _type_func('w', $1, $2),
+        'Function ' || quote_ident($1) || '(' ||
+        array_to_string($2, ', ') || ') should not be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_window( function, description )
+CREATE OR REPLACE FUNCTION isnt_window( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, NOT _type_func('w', $1), $2 );
+$$ LANGUAGE sql;
+
+-- isnt_window( function )
+CREATE OR REPLACE FUNCTION isnt_window( NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, NOT _type_func('w', $1),
+        'Function ' || quote_ident($1) || '() should not be a window function'
+    );
+$$ LANGUAGE sql;
+
+-- is_procedure( schema, function, args[], description )
+CREATE OR REPLACE FUNCTION is_procedure ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, $3, _type_func( 'p', $1, $2, $3), $4 );
+$$ LANGUAGE SQL;
+
+-- is_procedure( schema, function, args[] )
+CREATE OR REPLACE FUNCTION is_procedure( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, $3, _type_func('p', $1, $2, $3),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
+        array_to_string($3, ', ') || ') should be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- is_procedure( schema, function, description )
+CREATE OR REPLACE FUNCTION is_procedure ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, _type_func('p', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- is_procedure( schema, function )
+CREATE OR REPLACE FUNCTION is_procedure( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, _type_func('p', $1, $2),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- is_procedure( function, args[], description )
+CREATE OR REPLACE FUNCTION is_procedure ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, $2, _type_func('p', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- is_procedure( function, args[] )
+CREATE OR REPLACE FUNCTION is_procedure( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, $2, _type_func('p', $1, $2),
+        'Function ' || quote_ident($1) || '(' ||
+        array_to_string($2, ', ') || ') should be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- is_procedure( function, description )
+CREATE OR REPLACE FUNCTION is_procedure( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, _type_func('p', $1), $2 );
+$$ LANGUAGE sql;
+
+-- is_procedure( function )
+CREATE OR REPLACE FUNCTION is_procedure( NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, _type_func('p', $1),
+        'Function ' || quote_ident($1) || '() should be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_procedure( schema, function, args[], description )
+CREATE OR REPLACE FUNCTION isnt_procedure ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, $3, NOT _type_func('p', $1, $2, $3), $4 );
+$$ LANGUAGE SQL;
+
+-- isnt_procedure( schema, function, args[] )
+CREATE OR REPLACE FUNCTION isnt_procedure( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2, $3, NOT _type_func('p', $1, $2, $3),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '(' ||
+        array_to_string($3, ', ') || ') should not be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_procedure( schema, function, description )
+CREATE OR REPLACE FUNCTION isnt_procedure ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare($1, $2, NOT _type_func('p', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- isnt_procedure( schema, function )
+CREATE OR REPLACE FUNCTION isnt_procedure( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        $1, $2,  NOT _type_func('p', $1, $2),
+        'Function ' || quote_ident($1) || '.' || quote_ident($2) || '() should not be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_procedure( function, args[], description )
+CREATE OR REPLACE FUNCTION isnt_procedure ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, $2, NOT _type_func('p', $1, $2), $3 );
+$$ LANGUAGE SQL;
+
+-- isnt_procedure( function, args[] )
+CREATE OR REPLACE FUNCTION isnt_procedure( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, $2, NOT _type_func('p', $1, $2),
+        'Function ' || quote_ident($1) || '(' ||
+        array_to_string($2, ', ') || ') should not be a procedure'
+    );
+$$ LANGUAGE sql;
+
+-- isnt_procedure( function, description )
+CREATE OR REPLACE FUNCTION isnt_procedure( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT _func_compare(NULL, $1, NOT _type_func('p', $1), $2 );
+$$ LANGUAGE sql;
+
+-- isnt_procedure( function )
+CREATE OR REPLACE FUNCTION isnt_procedure( NAME )
+RETURNS TEXT AS $$
+    SELECT _func_compare(
+        NULL, $1, NOT _type_func('p', $1),
+        'Function ' || quote_ident($1) || '() should not be a procedure'
+    );
+$$ LANGUAGE sql;

--- a/test/expected/functap.out
+++ b/test/expected/functap.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..640
+1..1012
 ok 1 - simple function should pass
 ok 2 - simple function should have the proper description
 ok 3 - simple function should have the proper diagnostics
@@ -360,283 +360,655 @@ ok 357 - is_definer(func) should have the proper diagnostics
 ok 358 - isnt_definer(func) should fail
 ok 359 - isnt_definer(func) should have the proper description
 ok 360 - isnt_definer(func) should have the proper diagnostics
-ok 361 - is_aggregate(schema, func, arg, desc) should pass
-ok 362 - is_aggregate(schema, func, arg, desc) should have the proper description
-ok 363 - is_aggregate(schema, func, arg, desc) should have the proper diagnostics
-ok 364 - isnt_aggregate(schema, func, arg, desc) should fail
-ok 365 - isnt_aggregate(schema, func, arg, desc) should have the proper description
-ok 366 - isnt_aggregate(schema, func, arg, desc) should have the proper diagnostics
-ok 367 - is_aggregate(schema, func, arg) should pass
-ok 368 - is_aggregate(schema, func, arg) should have the proper description
-ok 369 - is_aggregate(schema, func, arg) should have the proper diagnostics
-ok 370 - isnt_aggregate(schema, func, arg) should fail
-ok 371 - isnt_aggregate(schema, func, arg) should have the proper description
-ok 372 - isnt_aggregate(schema, func, arg) should have the proper diagnostics
-ok 373 - is_aggregate(schema, func, args, desc) should fail
-ok 374 - is_aggregate(schema, func, args, desc) should have the proper description
-ok 375 - is_aggregate(schema, func, args, desc) should have the proper diagnostics
-ok 376 - isnt_aggregate(schema, func, args, desc) should pass
-ok 377 - isnt_aggregate(schema, func, args, desc) should have the proper description
-ok 378 - isnt_aggregate(schema, func, args, desc) should have the proper diagnostics
-ok 379 - is_aggregate(schema, func, args) should fail
-ok 380 - is_aggregate(schema, func, args) should have the proper description
-ok 381 - is_aggregate(schema, func, args) should have the proper diagnostics
-ok 382 - isnt_aggregate(schema, func, args) should pass
-ok 383 - isnt_aggregate(schema, func, args) should have the proper description
-ok 384 - isnt_aggregate(schema, func, args) should have the proper diagnostics
-ok 385 - is_aggregate(schema, func, desc) should pass
-ok 386 - is_aggregate(schema, func, desc) should have the proper description
-ok 387 - is_aggregate(schema, func, desc) should have the proper diagnostics
-ok 388 - isnt_aggregate(schema, func, desc) should fail
-ok 389 - isnt_aggregate(schema, func, desc) should have the proper description
-ok 390 - isnt_aggregate(schema, func, desc) should have the proper diagnostics
-ok 391 - is_aggregate(schema, func) should pass
-ok 392 - is_aggregate(schema, func) should have the proper description
-ok 393 - is_aggregate(schema, func) should have the proper diagnostics
-ok 394 - isnt_aggregate(schema, func) should fail
-ok 395 - isnt_aggregate(schema, func) should have the proper description
-ok 396 - isnt_aggregate(schema, func) should have the proper diagnostics
-ok 397 - is_aggregate(schema, func, arg, desc) should pass
-ok 398 - is_aggregate(schema, func, arg, desc) should have the proper description
-ok 399 - is_aggregate(schema, func, arg, desc) should have the proper diagnostics
-ok 400 - isnt_aggregate(schema, func, arg, desc) should fail
-ok 401 - isnt_aggregate(schema, func, arg, desc) should have the proper description
-ok 402 - isnt_aggregate(schema, func, arg, desc) should have the proper diagnostics
-ok 403 - is_aggregate(schema, func, arg) should pass
-ok 404 - is_aggregate(schema, func, arg) should have the proper description
-ok 405 - is_aggregate(schema, func, arg) should have the proper diagnostics
-ok 406 - isnt_aggregate(schema, func, arg) should fail
-ok 407 - isnt_aggregate(schema, func, arg) should have the proper description
-ok 408 - isnt_aggregate(schema, func, arg) should have the proper diagnostics
-ok 409 - is_aggregate(schema, func, args, desc) should fail
-ok 410 - is_aggregate(schema, func, args, desc) should have the proper description
-ok 411 - is_aggregate(schema, func, args, desc) should have the proper diagnostics
-ok 412 - isnt_aggregate(schema, func, args, desc) should pass
-ok 413 - isnt_aggregate(schema, func, args, desc) should have the proper description
-ok 414 - isnt_aggregate(schema, func, args, desc) should have the proper diagnostics
-ok 415 - is_aggregate(schema, func, args) should fail
-ok 416 - is_aggregate(schema, func, args) should have the proper description
-ok 417 - is_aggregate(schema, func, args) should have the proper diagnostics
-ok 418 - isnt_aggregate(schema, func, args) should pass
-ok 419 - isnt_aggregate(schema, func, args) should have the proper description
-ok 420 - isnt_aggregate(schema, func, args) should have the proper diagnostics
-ok 421 - is_aggregate(schema, func, desc) should pass
-ok 422 - is_aggregate(schema, func, desc) should have the proper description
-ok 423 - is_aggregate(schema, func, desc) should have the proper diagnostics
-ok 424 - isnt_aggregate(schema, func, desc) should fail
-ok 425 - isnt_aggregate(schema, func, desc) should have the proper description
-ok 426 - isnt_aggregate(schema, func, desc) should have the proper diagnostics
-ok 427 - is_aggregate(schema, func) should pass
-ok 428 - is_aggregate(schema, func) should have the proper description
-ok 429 - is_aggregate(schema, func) should have the proper diagnostics
-ok 430 - isnt_aggregate(schema, func) should fail
-ok 431 - isnt_aggregate(schema, func) should have the proper description
-ok 432 - isnt_aggregate(schema, func) should have the proper diagnostics
-ok 433 - is_aggregate(func, arg, desc) should pass
-ok 434 - is_aggregate(func, arg, desc) should have the proper description
-ok 435 - is_aggregate(func, arg, desc) should have the proper diagnostics
-ok 436 - isnt_aggregate(func, arg, desc) should fail
-ok 437 - isnt_aggregate(func, arg, desc) should have the proper description
-ok 438 - isnt_aggregate(func, arg, desc) should have the proper diagnostics
-ok 439 - is_aggregate(func, arg) should pass
-ok 440 - is_aggregate(func, arg) should have the proper description
-ok 441 - is_aggregate(func, arg) should have the proper diagnostics
-ok 442 - isnt_aggregate(func, arg) should fail
-ok 443 - isnt_aggregate(func, arg) should have the proper description
-ok 444 - isnt_aggregate(func, arg) should have the proper diagnostics
-ok 445 - is_aggregate(func, args, desc) should fail
-ok 446 - is_aggregate(func, args, desc) should have the proper description
-ok 447 - is_aggregate(func, args, desc) should have the proper diagnostics
-ok 448 - isnt_aggregate(func, args, desc) should pass
-ok 449 - isnt_aggregate(func, args, desc) should have the proper description
-ok 450 - isnt_aggregate(func, args, desc) should have the proper diagnostics
-ok 451 - is_aggregate(func, args) should fail
-ok 452 - is_aggregate(func, args) should have the proper description
-ok 453 - is_aggregate(func, args) should have the proper diagnostics
-ok 454 - isnt_aggregate(func, args) should pass
-ok 455 - isnt_aggregate(func, args) should have the proper description
-ok 456 - isnt_aggregate(func, args) should have the proper diagnostics
-ok 457 - is_aggregate(func, desc) should pass
-ok 458 - is_aggregate(func, desc) should have the proper description
-ok 459 - is_aggregate(func, desc) should have the proper diagnostics
-ok 460 - isnt_aggregate(func, desc) should fail
-ok 461 - isnt_aggregate(func, desc) should have the proper description
-ok 462 - isnt_aggregate(func, desc) should have the proper diagnostics
-ok 463 - is_aggregate(func) should pass
-ok 464 - is_aggregate(func) should have the proper description
-ok 465 - is_aggregate(func) should have the proper diagnostics
-ok 466 - isnt_aggregate(func) should fail
-ok 467 - isnt_aggregate(func) should have the proper description
-ok 468 - isnt_aggregate(func) should have the proper diagnostics
-ok 469 - is_strict(schema, func, 0 args, desc) should pass
-ok 470 - is_strict(schema, func, 0 args, desc) should have the proper description
-ok 471 - is_strict(schema, func, 0 args, desc) should have the proper diagnostics
-ok 472 - isnt_strict(schema, func, 0 args, desc) should fail
-ok 473 - isnt_strict(schema, func, 0 args, desc) should have the proper description
-ok 474 - isnt_strict(schema, func, 0 args, desc) should have the proper diagnostics
-ok 475 - is_strict(schema, func, 0 args) should pass
-ok 476 - is_strict(schema, func, 0 args) should have the proper description
-ok 477 - is_strict(schema, func, 0 args) should have the proper diagnostics
-ok 478 - isnt_strict(schema, func, 0 args) should fail
-ok 479 - isnt_strict(schema, func, 0 args) should have the proper description
-ok 480 - isnt_strict(schema, func, 0 args) should have the proper diagnostics
-ok 481 - is_strict(schema, func, args, desc) should fail
-ok 482 - is_strict(schema, func, args, desc) should have the proper description
-ok 483 - is_strict(schema, func, args, desc) should have the proper diagnostics
-ok 484 - is_strict(schema, func, args, desc) should pass
-ok 485 - is_strict(schema, func, args, desc) should have the proper description
-ok 486 - is_strict(schema, func, args, desc) should have the proper diagnostics
-ok 487 - is_strict(schema, func, args) should fail
-ok 488 - is_strict(schema, func, args) should have the proper description
-ok 489 - is_strict(schema, func, args) should have the proper diagnostics
-ok 490 - is_strict(schema, func, args) should pass
-ok 491 - is_strict(schema, func, args) should have the proper description
-ok 492 - is_strict(schema, func, args) should have the proper diagnostics
-ok 493 - is_strict(schema, func, desc) should pass
-ok 494 - is_strict(schema, func, desc) should have the proper description
-ok 495 - is_strict(schema, func, desc) should have the proper diagnostics
-ok 496 - isnt_strict(schema, func, desc) should fail
-ok 497 - isnt_strict(schema, func, desc) should have the proper description
-ok 498 - isnt_strict(schema, func, desc) should have the proper diagnostics
-ok 499 - is_strict(schema, func) should pass
-ok 500 - is_strict(schema, func) should have the proper description
-ok 501 - is_strict(schema, func) should have the proper diagnostics
-ok 502 - isnt_strict(schema, func) should fail
-ok 503 - isnt_strict(schema, func) should have the proper description
-ok 504 - isnt_strict(schema, func) should have the proper diagnostics
-ok 505 - is_strict(schema, func, 0 args, desc) should pass
-ok 506 - is_strict(schema, func, 0 args, desc) should have the proper description
-ok 507 - is_strict(schema, func, 0 args, desc) should have the proper diagnostics
-ok 508 - isnt_strict(schema, func, 0 args, desc) should fail
-ok 509 - isnt_strict(schema, func, 0 args, desc) should have the proper description
-ok 510 - isnt_strict(schema, func, 0 args, desc) should have the proper diagnostics
-ok 511 - is_strict(schema, func, 0 args) should pass
-ok 512 - is_strict(schema, func, 0 args) should have the proper description
-ok 513 - is_strict(schema, func, 0 args) should have the proper diagnostics
-ok 514 - isnt_strict(schema, func, 0 args) should fail
-ok 515 - isnt_strict(schema, func, 0 args) should have the proper description
-ok 516 - isnt_strict(schema, func, 0 args) should have the proper diagnostics
-ok 517 - is_strict(schema, func, args, desc) should fail
-ok 518 - is_strict(schema, func, args, desc) should have the proper description
-ok 519 - is_strict(schema, func, args, desc) should have the proper diagnostics
-ok 520 - isnt_strict(schema, func, args, desc) should pass
-ok 521 - isnt_strict(schema, func, args, desc) should have the proper description
-ok 522 - isnt_strict(schema, func, args, desc) should have the proper diagnostics
-ok 523 - is_strict(schema, func, args) should fail
-ok 524 - is_strict(schema, func, args) should have the proper description
-ok 525 - is_strict(schema, func, args) should have the proper diagnostics
-ok 526 - isnt_strict(schema, func, args) should pass
-ok 527 - isnt_strict(schema, func, args) should have the proper description
-ok 528 - isnt_strict(schema, func, args) should have the proper diagnostics
-ok 529 - is_strict(schema, func, desc) should pass
-ok 530 - is_strict(schema, func, desc) should have the proper description
-ok 531 - is_strict(schema, func, desc) should have the proper diagnostics
-ok 532 - isnt_strict(schema, func, desc) should fail
-ok 533 - isnt_strict(schema, func, desc) should have the proper description
-ok 534 - isnt_strict(schema, func, desc) should have the proper diagnostics
-ok 535 - is_strict(schema, func) should pass
-ok 536 - is_strict(schema, func) should have the proper description
-ok 537 - is_strict(schema, func) should have the proper diagnostics
-ok 538 - isnt_strict(schema, func) should fail
-ok 539 - isnt_strict(schema, func) should have the proper description
-ok 540 - isnt_strict(schema, func) should have the proper diagnostics
-ok 541 - is_strict(func, 0 args, desc) should pass
-ok 542 - is_strict(func, 0 args, desc) should have the proper description
-ok 543 - is_strict(func, 0 args, desc) should have the proper diagnostics
-ok 544 - isnt_strict(func, 0 args, desc) should fail
-ok 545 - isnt_strict(func, 0 args, desc) should have the proper description
-ok 546 - isnt_strict(func, 0 args, desc) should have the proper diagnostics
-ok 547 - is_strict(func, 0 args) should pass
-ok 548 - is_strict(func, 0 args) should have the proper description
-ok 549 - is_strict(func, 0 args) should have the proper diagnostics
-ok 550 - isnt_strict(func, 0 args) should fail
-ok 551 - isnt_strict(func, 0 args) should have the proper description
-ok 552 - isnt_strict(func, 0 args) should have the proper diagnostics
-ok 553 - is_strict(func, args, desc) should fail
-ok 554 - is_strict(func, args, desc) should have the proper description
-ok 555 - is_strict(func, args, desc) should have the proper diagnostics
-ok 556 - isnt_strict(func, args, desc) should pass
-ok 557 - isnt_strict(func, args, desc) should have the proper description
-ok 558 - isnt_strict(func, args, desc) should have the proper diagnostics
-ok 559 - is_strict(func, args) should fail
-ok 560 - is_strict(func, args) should have the proper description
-ok 561 - is_strict(func, args) should have the proper diagnostics
-ok 562 - isnt_strict(func, args) should pass
-ok 563 - isnt_strict(func, args) should have the proper description
-ok 564 - isnt_strict(func, args) should have the proper diagnostics
-ok 565 - is_strict(func, desc) should pass
-ok 566 - is_strict(func, desc) should have the proper description
-ok 567 - is_strict(func, desc) should have the proper diagnostics
-ok 568 - isnt_strict(func, desc) should fail
-ok 569 - isnt_strict(func, desc) should have the proper description
-ok 570 - isnt_strict(func, desc) should have the proper diagnostics
-ok 571 - is_strict(func) should pass
-ok 572 - is_strict(func) should have the proper description
-ok 573 - is_strict(func) should have the proper diagnostics
-ok 574 - isnt_strict(func) should fail
-ok 575 - isnt_strict(func) should have the proper description
-ok 576 - isnt_strict(func) should have the proper diagnostics
-ok 577 - function_volatility(schema, func, 0 args, volatile, desc) should pass
-ok 578 - function_volatility(schema, func, 0 args, volatile, desc) should have the proper description
-ok 579 - function_volatility(schema, func, 0 args, volatile, desc) should have the proper diagnostics
-ok 580 - function_volatility(schema, func, 0 args, VOLATILE, desc) should pass
-ok 581 - function_volatility(schema, func, 0 args, VOLATILE, desc) should have the proper description
-ok 582 - function_volatility(schema, func, 0 args, VOLATILE, desc) should have the proper diagnostics
-ok 583 - function_volatility(schema, func, 0 args, v, desc) should pass
-ok 584 - function_volatility(schema, func, 0 args, v, desc) should have the proper description
-ok 585 - function_volatility(schema, func, 0 args, v, desc) should have the proper diagnostics
-ok 586 - function_volatility(schema, func, args, immutable, desc) should pass
-ok 587 - function_volatility(schema, func, args, immutable, desc) should have the proper description
-ok 588 - function_volatility(schema, func, args, immutable, desc) should have the proper diagnostics
-ok 589 - function_volatility(schema, func, 0 args, stable, desc) should pass
-ok 590 - function_volatility(schema, func, 0 args, stable, desc) should have the proper description
-ok 591 - function_volatility(schema, func, 0 args, stable, desc) should have the proper diagnostics
-ok 592 - function_volatility(schema, func, 0 args, volatile) should pass
-ok 593 - function_volatility(schema, func, 0 args, volatile) should have the proper description
-ok 594 - function_volatility(schema, func, 0 args, volatile) should have the proper diagnostics
-ok 595 - function_volatility(schema, func, args, immutable) should pass
-ok 596 - function_volatility(schema, func, args, immutable) should have the proper description
-ok 597 - function_volatility(schema, func, volatile, desc) should pass
-ok 598 - function_volatility(schema, func, volatile, desc) should have the proper description
-ok 599 - function_volatility(schema, func, volatile, desc) should have the proper diagnostics
-ok 600 - function_volatility(schema, func, volatile) should pass
-ok 601 - function_volatility(schema, func, volatile) should have the proper description
-ok 602 - function_volatility(schema, func, volatile) should have the proper diagnostics
-ok 603 - function_volatility(schema, func, immutable, desc) should pass
-ok 604 - function_volatility(schema, func, immutable, desc) should have the proper description
-ok 605 - function_volatility(schema, func, immutable, desc) should have the proper diagnostics
-ok 606 - function_volatility(schema, func, stable, desc) should pass
-ok 607 - function_volatility(schema, func, stable, desc) should have the proper description
-ok 608 - function_volatility(schema, func, stable, desc) should have the proper diagnostics
-ok 609 - function_volatility(func, 0 args, volatile, desc) should pass
-ok 610 - function_volatility(func, 0 args, volatile, desc) should have the proper description
-ok 611 - function_volatility(func, 0 args, volatile, desc) should have the proper diagnostics
-ok 612 - function_volatility(func, 0 args, VOLATILE, desc) should pass
-ok 613 - function_volatility(func, 0 args, VOLATILE, desc) should have the proper description
-ok 614 - function_volatility(func, 0 args, VOLATILE, desc) should have the proper diagnostics
-ok 615 - function_volatility(func, 0 args, v, desc) should pass
-ok 616 - function_volatility(func, 0 args, v, desc) should have the proper description
-ok 617 - function_volatility(func, 0 args, v, desc) should have the proper diagnostics
-ok 618 - function_volatility(func, args, immutable, desc) should pass
-ok 619 - function_volatility(func, args, immutable, desc) should have the proper description
-ok 620 - function_volatility(func, args, immutable, desc) should have the proper diagnostics
-ok 621 - function_volatility(func, 0 args, stable, desc) should pass
-ok 622 - function_volatility(func, 0 args, stable, desc) should have the proper description
-ok 623 - function_volatility(func, 0 args, stable, desc) should have the proper diagnostics
-ok 624 - function_volatility(func, 0 args, volatile) should pass
-ok 625 - function_volatility(func, 0 args, volatile) should have the proper description
-ok 626 - function_volatility(func, 0 args, volatile) should have the proper diagnostics
-ok 627 - function_volatility(func, args, immutable) should pass
-ok 628 - function_volatility(func, args, immutable) should have the proper description
-ok 629 - function_volatility(func, volatile, desc) should pass
-ok 630 - function_volatility(func, volatile, desc) should have the proper description
-ok 631 - function_volatility(func, volatile, desc) should have the proper diagnostics
-ok 632 - function_volatility(func, volatile) should pass
-ok 633 - function_volatility(func, volatile) should have the proper description
-ok 634 - function_volatility(func, volatile) should have the proper diagnostics
-ok 635 - function_volatility(func, immutable, desc) should pass
-ok 636 - function_volatility(func, immutable, desc) should have the proper description
-ok 637 - function_volatility(func, immutable, desc) should have the proper diagnostics
-ok 638 - function_volatility(func, stable, desc) should pass
-ok 639 - function_volatility(func, stable, desc) should have the proper description
-ok 640 - function_volatility(func, stable, desc) should have the proper diagnostics
+ok 361 - is_normal_function(schema, func, noargs, desc) should pass
+ok 362 - is_normal_function(schema, func, noargs, desc) should have the proper description
+ok 363 - is_normal_function(schema, func, noargs, desc) should have the proper diagnostics
+ok 364 - is_normal_function(schema, agg, arg, desc) should fail
+ok 365 - is_normal_function(schema, agg, arg, desc) should have the proper description
+ok 366 - is_normal_function(schema, agg, arg, desc) should have the proper diagnostics
+ok 367 - isnt_normal_function(schema, func, noargs, desc) should fail
+ok 368 - isnt_normal_function(schema, func, noargs, desc) should have the proper description
+ok 369 - isnt_normal_function(schema, func, noargs, desc) should have the proper diagnostics
+ok 370 - isnt_normal_function(schema, agg, noargs, desc) should pass
+ok 371 - isnt_normal_function(schema, agg, noargs, desc) should have the proper description
+ok 372 - isnt_normal_function(schema, agg, noargs, desc) should have the proper diagnostics
+ok 373 - is_normal_function(schema, func, args, desc) should pass
+ok 374 - is_normal_function(schema, func, args, desc) should have the proper description
+ok 375 - is_normal_function(schema, func, args, desc) should have the proper diagnostics
+ok 376 - is_normal_function(schema, agg, args, desc) should fail
+ok 377 - is_normal_function(schema, agg, args, desc) should have the proper description
+ok 378 - is_normal_function(schema, agg, args, desc) should have the proper diagnostics
+ok 379 - is_normal_function(schema, func, args, desc) should fail
+ok 380 - is_normal_function(schema, func, args, desc) should have the proper description
+ok 381 - is_normal_function(schema, func, args, desc) should have the proper diagnostics
+ok 382 - isnt_normal_function(schema, agg, args, desc) should pass
+ok 383 - isnt_normal_function(schema, agg, args, desc) should have the proper description
+ok 384 - isnt_normal_function(schema, agg, args, desc) should have the proper diagnostics
+ok 385 - is_normal_function(schema, nofunc, noargs, desc) should fail
+ok 386 - is_normal_function(schema, nofunc, noargs, desc) should have the proper description
+ok 387 - is_normal_function(schema, nofunc, noargs, desc) should have the proper diagnostics
+ok 388 - isnt_normal_function(schema, noagg, args, desc) should fail
+ok 389 - isnt_normal_function(schema, noagg, args, desc) should have the proper description
+ok 390 - isnt_normal_function(schema, noagg, args, desc) should have the proper diagnostics
+ok 391 - is_normal_function(schema, func, noargs) should pass
+ok 392 - is_normal_function(schema, func, noargs) should have the proper description
+ok 393 - is_normal_function(schema, func, noargs) should have the proper diagnostics
+ok 394 - is_normal_function(schema, agg, noargs) should fail
+ok 395 - is_normal_function(schema, agg, noargs) should have the proper description
+ok 396 - is_normal_function(schema, agg, noargs) should have the proper diagnostics
+ok 397 - isnt_normal_function(schema, func, noargs) should fail
+ok 398 - isnt_normal_function(schema, func, noargs) should have the proper description
+ok 399 - isnt_normal_function(schema, func, noargs) should have the proper diagnostics
+ok 400 - isnt_normal_function(schema, agg, noargs) should pass
+ok 401 - isnt_normal_function(schema, agg, noargs) should have the proper description
+ok 402 - isnt_normal_function(schema, agg, noargs) should have the proper diagnostics
+ok 403 - is_normal_function(schema, func2, args) should pass
+ok 404 - is_normal_function(schema, func2, args) should have the proper description
+ok 405 - is_normal_function(schema, func2, args) should have the proper diagnostics
+ok 406 - isnt_normal_function(schema, func2, args) should fail
+ok 407 - isnt_normal_function(schema, func2, args) should have the proper description
+ok 408 - isnt_normal_function(schema, func2, args) should have the proper diagnostics
+ok 409 - is_normal_function(schema, func, noargs) should fail
+ok 410 - is_normal_function(schema, func, noargs) should have the proper description
+ok 411 - is_normal_function(schema, func, noargs) should have the proper diagnostics
+ok 412 - is_normal_function(schema, nofunc, noargs) should fail
+ok 413 - is_normal_function(schema, nofunc, noargs) should have the proper description
+ok 414 - is_normal_function(schema, nofunc, noargs) should have the proper diagnostics
+ok 415 - is_normal_function(schema, func, desc) should pass
+ok 416 - is_normal_function(schema, func, desc) should have the proper description
+ok 417 - is_normal_function(schema, func, desc) should have the proper diagnostics
+ok 418 - is_normal_function(schema, agg, desc) should fail
+ok 419 - is_normal_function(schema, agg, desc) should have the proper description
+ok 420 - is_normal_function(schema, agg, desc) should have the proper diagnostics
+ok 421 - isnt_normal_function(schema, func, desc) should fail
+ok 422 - isnt_normal_function(schema, func, desc) should have the proper description
+ok 423 - isnt_normal_function(schema, func, desc) should have the proper diagnostics
+ok 424 - isnt_normal_function(schema, agg, desc) should pass
+ok 425 - isnt_normal_function(schema, agg, desc) should have the proper description
+ok 426 - isnt_normal_function(schema, agg, desc) should have the proper diagnostics
+ok 427 - is_normal_function(schema, func2, desc) should pass
+ok 428 - is_normal_function(schema, func2, desc) should have the proper description
+ok 429 - is_normal_function(schema, func2, desc) should have the proper diagnostics
+ok 430 - isnt_normal_function(schema, func2, desc) should fail
+ok 431 - isnt_normal_function(schema, func2, desc) should have the proper description
+ok 432 - isnt_normal_function(schema, func2, desc) should have the proper diagnostics
+ok 433 - is_normal_function(schema, nofunc, desc) should fail
+ok 434 - is_normal_function(schema, nofunc, desc) should have the proper description
+ok 435 - is_normal_function(schema, nofunc, desc) should have the proper diagnostics
+ok 436 - is_normal_function(schema, noagg, desc) should fail
+ok 437 - is_normal_function(schema, noagg, desc) should have the proper description
+ok 438 - is_normal_function(schema, noagg, desc) should have the proper diagnostics
+ok 439 - is_normal_function(schema, func) should pass
+ok 440 - is_normal_function(schema, func) should have the proper description
+ok 441 - is_normal_function(schema, func) should have the proper diagnostics
+ok 442 - is_normal_function(schema, agg) should fail
+ok 443 - is_normal_function(schema, agg) should have the proper description
+ok 444 - is_normal_function(schema, agg) should have the proper diagnostics
+ok 445 - isnt_normal_function(schema, func) should fail
+ok 446 - isnt_normal_function(schema, func) should have the proper description
+ok 447 - isnt_normal_function(schema, func) should have the proper diagnostics
+ok 448 - isnt_normal_function(schema, agg) should pass
+ok 449 - isnt_normal_function(schema, agg) should have the proper description
+ok 450 - isnt_normal_function(schema, agg) should have the proper diagnostics
+ok 451 - is_normal_function(schema, func2, args) should pass
+ok 452 - is_normal_function(schema, func2, args) should have the proper description
+ok 453 - is_normal_function(schema, func2, args) should have the proper diagnostics
+ok 454 - isnt_normal_function(schema, func2) should fail
+ok 455 - isnt_normal_function(schema, func2) should have the proper description
+ok 456 - isnt_normal_function(schema, func2) should have the proper diagnostics
+ok 457 - is_normal_function(schema, nofunc) should fail
+ok 458 - is_normal_function(schema, nofunc) should have the proper description
+ok 459 - is_normal_function(schema, nofunc) should have the proper diagnostics
+ok 460 - is_normal_function(schema, nogg) should fail
+ok 461 - is_normal_function(schema, nogg) should have the proper description
+ok 462 - is_normal_function(schema, nogg) should have the proper diagnostics
+ok 463 - is_normal_function(func, noargs, desc) should pass
+ok 464 - is_normal_function(func, noargs, desc) should have the proper description
+ok 465 - is_normal_function(func, noargs, desc) should have the proper diagnostics
+ok 466 - is_normal_function(func, agg, desc) should fail
+ok 467 - is_normal_function(func, agg, desc) should have the proper description
+ok 468 - is_normal_function(func, agg, desc) should have the proper diagnostics
+ok 469 - isnt_normal_function(func, noargs, desc) should fail
+ok 470 - isnt_normal_function(func, noargs, desc) should have the proper description
+ok 471 - isnt_normal_function(func, noargs, desc) should have the proper diagnostics
+ok 472 - isnt_normal_function(func, agg, desc) should pass
+ok 473 - isnt_normal_function(func, agg, desc) should have the proper description
+ok 474 - isnt_normal_function(func, agg, desc) should have the proper diagnostics
+ok 475 - is_normal_function(func, args, desc) should pass
+ok 476 - is_normal_function(func, args, desc) should have the proper description
+ok 477 - is_normal_function(func, args, desc) should have the proper diagnostics
+ok 478 - isnt_normal_function(func, args, desc) should fail
+ok 479 - isnt_normal_function(func, args, desc) should have the proper description
+ok 480 - isnt_normal_function(func, args, desc) should have the proper diagnostics
+ok 481 - is_normal_function(nofunc, noargs, desc) should fail
+ok 482 - is_normal_function(nofunc, noargs, desc) should have the proper description
+ok 483 - is_normal_function(nofunc, noargs, desc) should have the proper diagnostics
+ok 484 - is_normal_function(func, noagg, desc) should fail
+ok 485 - is_normal_function(func, noagg, desc) should have the proper description
+ok 486 - is_normal_function(func, noagg, desc) should have the proper diagnostics
+ok 487 - is_normal_function(func, noargs) should pass
+ok 488 - is_normal_function(func, noargs) should have the proper description
+ok 489 - is_normal_function(func, noargs) should have the proper diagnostics
+ok 490 - isnt_normal_function(func, noargs) should fail
+ok 491 - isnt_normal_function(func, noargs) should have the proper description
+ok 492 - isnt_normal_function(func, noargs) should have the proper diagnostics
+ok 493 - is_normal_function(func, noargs) should pass
+ok 494 - is_normal_function(func, noargs) should have the proper description
+ok 495 - is_normal_function(func, noargs) should have the proper diagnostics
+ok 496 - isnt_normal_function(func, noargs) should fail
+ok 497 - isnt_normal_function(func, noargs) should have the proper description
+ok 498 - isnt_normal_function(func, noargs) should have the proper diagnostics
+ok 499 - is_normal_function(nofunc, noargs) should fail
+ok 500 - is_normal_function(nofunc, noargs) should have the proper description
+ok 501 - is_normal_function(nofunc, noargs) should have the proper diagnostics
+ok 502 - isnt_normal_function(fnounc, noargs) should fail
+ok 503 - isnt_normal_function(fnounc, noargs) should have the proper description
+ok 504 - isnt_normal_function(fnounc, noargs) should have the proper diagnostics
+ok 505 - is_normal_function(func, desc) should pass
+ok 506 - is_normal_function(func, desc) should have the proper description
+ok 507 - is_normal_function(func, desc) should have the proper diagnostics
+ok 508 - is_normal_function(agg, desc) should fail
+ok 509 - is_normal_function(agg, desc) should have the proper description
+ok 510 - is_normal_function(agg, desc) should have the proper diagnostics
+ok 511 - isnt_normal_function(func, desc) should fail
+ok 512 - isnt_normal_function(func, desc) should have the proper description
+ok 513 - isnt_normal_function(func, desc) should have the proper diagnostics
+ok 514 - isnt_normal_function(agg, desc) should pass
+ok 515 - isnt_normal_function(agg, desc) should have the proper description
+ok 516 - isnt_normal_function(agg, desc) should have the proper diagnostics
+ok 517 - is_normal_function(func2, desc) should pass
+ok 518 - is_normal_function(func2, desc) should have the proper description
+ok 519 - is_normal_function(func2, desc) should have the proper diagnostics
+ok 520 - isnt_normal_function(func2, desc) should fail
+ok 521 - isnt_normal_function(func2, desc) should have the proper description
+ok 522 - isnt_normal_function(func2, desc) should have the proper diagnostics
+ok 523 - is_normal_function(nofunc, desc) should fail
+ok 524 - is_normal_function(nofunc, desc) should have the proper description
+ok 525 - is_normal_function(nofunc, desc) should have the proper diagnostics
+ok 526 - is_normal_function(noagg, desc) should fail
+ok 527 - is_normal_function(noagg, desc) should have the proper description
+ok 528 - is_normal_function(noagg, desc) should have the proper diagnostics
+ok 529 - is_normal_function(func) should pass
+ok 530 - is_normal_function(func) should have the proper description
+ok 531 - is_normal_function(func) should have the proper diagnostics
+ok 532 - is_normal_function(agg) should fail
+ok 533 - is_normal_function(agg) should have the proper description
+ok 534 - is_normal_function(agg) should have the proper diagnostics
+ok 535 - isnt_normal_function(func) should fail
+ok 536 - isnt_normal_function(func) should have the proper description
+ok 537 - isnt_normal_function(func) should have the proper diagnostics
+ok 538 - isnt_normal_function(agg) should pass
+ok 539 - isnt_normal_function(agg) should have the proper description
+ok 540 - isnt_normal_function(agg) should have the proper diagnostics
+ok 541 - is_normal_function(func2) should pass
+ok 542 - is_normal_function(func2) should have the proper description
+ok 543 - is_normal_function(func2) should have the proper diagnostics
+ok 544 - isnt_normal_function(func2,) should fail
+ok 545 - isnt_normal_function(func2,) should have the proper description
+ok 546 - isnt_normal_function(func2,) should have the proper diagnostics
+ok 547 - is_normal_function(nofunc) should fail
+ok 548 - is_normal_function(nofunc) should have the proper description
+ok 549 - is_normal_function(nofunc) should have the proper diagnostics
+ok 550 - is_normal_function(noagg) should fail
+ok 551 - is_normal_function(noagg) should have the proper description
+ok 552 - is_normal_function(noagg) should have the proper diagnostics
+ok 553 - is_aggregate(schema, func, arg, desc) should pass
+ok 554 - is_aggregate(schema, func, arg, desc) should have the proper description
+ok 555 - is_aggregate(schema, func, arg, desc) should have the proper diagnostics
+ok 556 - isnt_aggregate(schema, agg, arg, desc) should fail
+ok 557 - isnt_aggregate(schema, agg, arg, desc) should have the proper description
+ok 558 - isnt_aggregate(schema, agg, arg, desc) should have the proper diagnostics
+ok 559 - is_aggregate(schema, func, args, desc) should fail
+ok 560 - is_aggregate(schema, func, args, desc) should have the proper description
+ok 561 - is_aggregate(schema, func, args, desc) should have the proper diagnostics
+ok 562 - isnt_aggregate(schema, func, args, desc) should pass
+ok 563 - isnt_aggregate(schema, func, args, desc) should have the proper description
+ok 564 - isnt_aggregate(schema, func, args, desc) should have the proper diagnostics
+ok 565 - is_aggregate(schema, nofunc, arg, desc) should fail
+ok 566 - is_aggregate(schema, nofunc, arg, desc) should have the proper description
+ok 567 - is_aggregate(schema, nofunc, arg, desc) should have the proper diagnostics
+ok 568 - isnt_aggregate(schema, noagg, arg, desc) should fail
+ok 569 - isnt_aggregate(schema, noagg, arg, desc) should have the proper description
+ok 570 - isnt_aggregate(schema, noagg, arg, desc) should have the proper diagnostics
+ok 571 - is_aggregate(schema, agg, arg) should pass
+ok 572 - is_aggregate(schema, agg, arg) should have the proper description
+ok 573 - is_aggregate(schema, agg, arg) should have the proper diagnostics
+ok 574 - isnt_aggregate(schema, agg, arg) should fail
+ok 575 - isnt_aggregate(schema, agg, arg) should have the proper description
+ok 576 - isnt_aggregate(schema, agg, arg) should have the proper diagnostics
+ok 577 - is_aggregate(schema, func, args) should fail
+ok 578 - is_aggregate(schema, func, args) should have the proper description
+ok 579 - is_aggregate(schema, func, args) should have the proper diagnostics
+ok 580 - isnt_aggregate(schema, func, args) should pass
+ok 581 - isnt_aggregate(schema, func, args) should have the proper description
+ok 582 - isnt_aggregate(schema, func, args) should have the proper diagnostics
+ok 583 - is_aggregate(schema, noagg, arg) should fail
+ok 584 - is_aggregate(schema, noagg, arg) should have the proper description
+ok 585 - is_aggregate(schema, noagg, arg) should have the proper diagnostics
+ok 586 - isnt_aggregate(schema, noagg, arg) should fail
+ok 587 - isnt_aggregate(schema, noagg, arg) should have the proper description
+ok 588 - isnt_aggregate(schema, noagg, arg) should have the proper diagnostics
+ok 589 - is_aggregate(schema, agg, desc) should pass
+ok 590 - is_aggregate(schema, agg, desc) should have the proper description
+ok 591 - is_aggregate(schema, agg, desc) should have the proper diagnostics
+ok 592 - isnt_aggregate(schema, agg, desc) should fail
+ok 593 - isnt_aggregate(schema, agg, desc) should have the proper description
+ok 594 - isnt_aggregate(schema, agg, desc) should have the proper diagnostics
+ok 595 - is_aggregate(schema, noagg, desc) should fail
+ok 596 - is_aggregate(schema, noagg, desc) should have the proper description
+ok 597 - is_aggregate(schema, noagg, desc) should have the proper diagnostics
+ok 598 - isnt_aggregate(schema, noagg, desc) should fail
+ok 599 - isnt_aggregate(schema, noagg, desc) should have the proper description
+ok 600 - isnt_aggregate(schema, noagg, desc) should have the proper diagnostics
+ok 601 - is_aggregate(schema, agg) should pass
+ok 602 - is_aggregate(schema, agg) should have the proper description
+ok 603 - is_aggregate(schema, agg) should have the proper diagnostics
+ok 604 - isnt_aggregate(schema, agg) should fail
+ok 605 - isnt_aggregate(schema, agg) should have the proper description
+ok 606 - isnt_aggregate(schema, agg) should have the proper diagnostics
+ok 607 - is_aggregate(schema, noagg) should fail
+ok 608 - is_aggregate(schema, noagg) should have the proper description
+ok 609 - is_aggregate(schema, noagg) should have the proper diagnostics
+ok 610 - isnt_aggregate(schema, noagg) should fail
+ok 611 - isnt_aggregate(schema, noagg) should have the proper description
+ok 612 - isnt_aggregate(schema, noagg) should have the proper diagnostics
+ok 613 - is_aggregate(agg, arg, desc) should pass
+ok 614 - is_aggregate(agg, arg, desc) should have the proper description
+ok 615 - is_aggregate(agg, arg, desc) should have the proper diagnostics
+ok 616 - isnt_aggregate(agg, arg, desc) should fail
+ok 617 - isnt_aggregate(agg, arg, desc) should have the proper description
+ok 618 - isnt_aggregate(agg, arg, desc) should have the proper diagnostics
+ok 619 - is_aggregate(func, args, desc) should fail
+ok 620 - is_aggregate(func, args, desc) should have the proper description
+ok 621 - is_aggregate(func, args, desc) should have the proper diagnostics
+ok 622 - isnt_aggregate(func, args, desc) should pass
+ok 623 - isnt_aggregate(func, args, desc) should have the proper description
+ok 624 - isnt_aggregate(func, args, desc) should have the proper diagnostics
+ok 625 - is_aggregate(noagg, arg, desc) should fail
+ok 626 - is_aggregate(noagg, arg, desc) should have the proper description
+ok 627 - is_aggregate(noagg, arg, desc) should have the proper diagnostics
+ok 628 - isnt_aggregate(noagg, arg, desc) should fail
+ok 629 - isnt_aggregate(noagg, arg, desc) should have the proper description
+ok 630 - isnt_aggregate(noagg, arg, desc) should have the proper diagnostics
+ok 631 - is_aggregate(agg, arg) should pass
+ok 632 - is_aggregate(agg, arg) should have the proper description
+ok 633 - is_aggregate(agg, arg) should have the proper diagnostics
+ok 634 - isnt_aggregate(agg, arg) should fail
+ok 635 - isnt_aggregate(agg, arg) should have the proper description
+ok 636 - isnt_aggregate(agg, arg) should have the proper diagnostics
+ok 637 - is_aggregate(func, args) should fail
+ok 638 - is_aggregate(func, args) should have the proper description
+ok 639 - is_aggregate(func, args) should have the proper diagnostics
+ok 640 - isnt_aggregate(func, args) should pass
+ok 641 - isnt_aggregate(func, args) should have the proper description
+ok 642 - isnt_aggregate(func, args) should have the proper diagnostics
+ok 643 - is_aggregate(noagg, arg) should fail
+ok 644 - is_aggregate(noagg, arg) should have the proper description
+ok 645 - is_aggregate(noagg, arg) should have the proper diagnostics
+ok 646 - isnt_aggregate(noagg, arg) should fail
+ok 647 - isnt_aggregate(noagg, arg) should have the proper description
+ok 648 - isnt_aggregate(noagg, arg) should have the proper diagnostics
+ok 649 - is_aggregate(func, desc) should pass
+ok 650 - is_aggregate(func, desc) should have the proper description
+ok 651 - is_aggregate(func, desc) should have the proper diagnostics
+ok 652 - isnt_aggregate(agg, desc) should fail
+ok 653 - isnt_aggregate(agg, desc) should have the proper description
+ok 654 - isnt_aggregate(agg, desc) should have the proper diagnostics
+ok 655 - is_aggregate(nofunc, desc) should fail
+ok 656 - is_aggregate(nofunc, desc) should have the proper description
+ok 657 - is_aggregate(nofunc, desc) should have the proper diagnostics
+ok 658 - isnt_aggregate(noagg, desc) should fail
+ok 659 - isnt_aggregate(noagg, desc) should have the proper description
+ok 660 - isnt_aggregate(noagg, desc) should have the proper diagnostics
+ok 661 - is_aggregate(agg) should pass
+ok 662 - is_aggregate(agg) should have the proper description
+ok 663 - is_aggregate(agg) should have the proper diagnostics
+ok 664 - isnt_aggregate(agg) should fail
+ok 665 - isnt_aggregate(agg) should have the proper description
+ok 666 - isnt_aggregate(agg) should have the proper diagnostics
+ok 667 - is_aggregate(noagg) should fail
+ok 668 - is_aggregate(noagg) should have the proper description
+ok 669 - is_aggregate(noagg) should have the proper diagnostics
+ok 670 - isnt_aggregate(noagg) should fail
+ok 671 - isnt_aggregate(noagg) should have the proper description
+ok 672 - isnt_aggregate(noagg) should have the proper diagnostics
+ok 673 - is_window(schema, win, arg, desc) should pass
+ok 674 - is_window(schema, win, arg, desc) should have the proper description
+ok 675 - is_window(schema, win, arg, desc) should have the proper diagnostics
+ok 676 - isnt_window(schema, win, arg, desc) should fail
+ok 677 - isnt_window(schema, win, arg, desc) should have the proper description
+ok 678 - isnt_window(schema, win, arg, desc) should have the proper diagnostics
+ok 679 - is_window(schema, func, arg, desc) should fail
+ok 680 - is_window(schema, func, arg, desc) should have the proper description
+ok 681 - is_window(schema, func, arg, desc) should have the proper diagnostics
+ok 682 - isnt_window(schema, func, arg, desc) should pass
+ok 683 - isnt_window(schema, func, arg, desc) should have the proper description
+ok 684 - isnt_window(schema, func, arg, desc) should have the proper diagnostics
+ok 685 - is_window(schema, win, noargs, desc) should pass
+ok 686 - is_window(schema, win, noargs, desc) should have the proper description
+ok 687 - is_window(schema, win, noargs, desc) should have the proper diagnostics
+ok 688 - isnt_window(schema, win, noargs, desc) should fail
+ok 689 - isnt_window(schema, win, noargs, desc) should have the proper description
+ok 690 - isnt_window(schema, win, noargs, desc) should have the proper diagnostics
+ok 691 - is_window(schema, func, noarg, desc) should fail
+ok 692 - is_window(schema, func, noarg, desc) should have the proper description
+ok 693 - is_window(schema, func, noarg, desc) should have the proper diagnostics
+ok 694 - is_window(schema, win, noargs, desc) should fail
+ok 695 - is_window(schema, win, noargs, desc) should have the proper description
+ok 696 - is_window(schema, win, noargs, desc) should have the proper diagnostics
+ok 697 - is_window(schema, nowin, arg, desc) should fail
+ok 698 - is_window(schema, nowin, arg, desc) should have the proper description
+ok 699 - is_window(schema, nowin, arg, desc) should have the proper diagnostics
+ok 700 - isnt_window(schema, nowin, arg, desc) should fail
+ok 701 - isnt_window(schema, nowin, arg, desc) should have the proper description
+ok 702 - isnt_window(schema, nowin, arg, desc) should have the proper diagnostics
+ok 703 - is_window(schema, win, arg) should pass
+ok 704 - is_window(schema, win, arg) should have the proper description
+ok 705 - is_window(schema, win, arg) should have the proper diagnostics
+ok 706 - isnt_window(schema, win, arg) should fail
+ok 707 - isnt_window(schema, win, arg) should have the proper description
+ok 708 - isnt_window(schema, win, arg) should have the proper diagnostics
+ok 709 - is_window(schema, func, arg) should fail
+ok 710 - is_window(schema, func, arg) should have the proper description
+ok 711 - is_window(schema, func, arg) should have the proper diagnostics
+ok 712 - isnt_window(schema, func, arg) should pass
+ok 713 - isnt_window(schema, func, arg) should have the proper description
+ok 714 - isnt_window(schema, func, arg) should have the proper diagnostics
+ok 715 - is_window(schema, win, noargs) should pass
+ok 716 - is_window(schema, win, noargs) should have the proper description
+ok 717 - is_window(schema, win, noargs) should have the proper diagnostics
+ok 718 - isnt_window(schema, win, noargs) should fail
+ok 719 - isnt_window(schema, win, noargs) should have the proper description
+ok 720 - isnt_window(schema, win, noargs) should have the proper diagnostics
+ok 721 - is_window(schema, func, noarg) should fail
+ok 722 - is_window(schema, func, noarg) should have the proper description
+ok 723 - is_window(schema, func, noarg) should have the proper diagnostics
+ok 724 - isnt_window(schema, win, noargs) should fail
+ok 725 - isnt_window(schema, win, noargs) should have the proper description
+ok 726 - isnt_window(schema, win, noargs) should have the proper diagnostics
+ok 727 - is_window(schema, nowin, arg) should fail
+ok 728 - is_window(schema, nowin, arg) should have the proper description
+ok 729 - is_window(schema, nowin, arg) should have the proper diagnostics
+ok 730 - isnt_window(schema, nowin, arg) should fail
+ok 731 - isnt_window(schema, nowin, arg) should have the proper description
+ok 732 - isnt_window(schema, nowin, arg) should have the proper diagnostics
+ok 733 - is_window(schema, win, desc) should pass
+ok 734 - is_window(schema, win, desc) should have the proper description
+ok 735 - is_window(schema, win, desc) should have the proper diagnostics
+ok 736 - isnt_window(schema, win, desc) should fail
+ok 737 - isnt_window(schema, win, desc) should have the proper description
+ok 738 - isnt_window(schema, win, desc) should have the proper diagnostics
+ok 739 - is_window(schema, func, desc) should fail
+ok 740 - is_window(schema, func, desc) should have the proper description
+ok 741 - is_window(schema, func, desc) should have the proper diagnostics
+ok 742 - isnt_window(schema, func, desc) should pass
+ok 743 - isnt_window(schema, func, desc) should have the proper description
+ok 744 - isnt_window(schema, func, desc) should have the proper diagnostics
+ok 745 - is_window(schema, func, desc) should fail
+ok 746 - is_window(schema, func, desc) should have the proper description
+ok 747 - is_window(schema, func, desc) should have the proper diagnostics
+ok 748 - isnt_window(schema, win, desc) should fail
+ok 749 - isnt_window(schema, win, desc) should have the proper description
+ok 750 - isnt_window(schema, win, desc) should have the proper diagnostics
+ok 751 - is_window(schema, nowin, desc) should fail
+ok 752 - is_window(schema, nowin, desc) should have the proper description
+ok 753 - is_window(schema, nowin, desc) should have the proper diagnostics
+ok 754 - isnt_window(schema, nowin, desc) should fail
+ok 755 - isnt_window(schema, nowin, desc) should have the proper description
+ok 756 - isnt_window(schema, nowin, desc) should have the proper diagnostics
+ok 757 - is_window(schema, win) should pass
+ok 758 - is_window(schema, win) should have the proper description
+ok 759 - is_window(schema, win) should have the proper diagnostics
+ok 760 - isnt_window(schema, win) should fail
+ok 761 - isnt_window(schema, win) should have the proper description
+ok 762 - isnt_window(schema, win) should have the proper diagnostics
+ok 763 - is_window(schema, func) should fail
+ok 764 - is_window(schema, func) should have the proper description
+ok 765 - is_window(schema, func) should have the proper diagnostics
+ok 766 - isnt_window(schema, func) should pass
+ok 767 - isnt_window(schema, func) should have the proper description
+ok 768 - isnt_window(schema, func) should have the proper diagnostics
+ok 769 - is_window(schema, nowin) should fail
+ok 770 - is_window(schema, nowin) should have the proper description
+ok 771 - is_window(schema, nowin) should have the proper diagnostics
+ok 772 - isnt_window(schema, nowin) should fail
+ok 773 - isnt_window(schema, nowin) should have the proper description
+ok 774 - isnt_window(schema, nowin) should have the proper diagnostics
+ok 775 - is_window(win, arg, desc) should pass
+ok 776 - is_window(win, arg, desc) should have the proper description
+ok 777 - is_window(win, arg, desc) should have the proper diagnostics
+ok 778 - isnt_window(win, arg, desc) should fail
+ok 779 - isnt_window(win, arg, desc) should have the proper description
+ok 780 - isnt_window(win, arg, desc) should have the proper diagnostics
+ok 781 - is_window(func, arg, desc) should fail
+ok 782 - is_window(func, arg, desc) should have the proper description
+ok 783 - is_window(func, arg, desc) should have the proper diagnostics
+ok 784 - isnt_window(func, arg, desc) should pass
+ok 785 - isnt_window(func, arg, desc) should have the proper description
+ok 786 - isnt_window(func, arg, desc) should have the proper diagnostics
+ok 787 - is_window(win, noargs, desc) should pass
+ok 788 - is_window(win, noargs, desc) should have the proper description
+ok 789 - is_window(win, noargs, desc) should have the proper diagnostics
+ok 790 - isnt_window(win, noargs, desc) should fail
+ok 791 - isnt_window(win, noargs, desc) should have the proper description
+ok 792 - isnt_window(win, noargs, desc) should have the proper diagnostics
+ok 793 - is_window(func, noarg, desc) should fail
+ok 794 - is_window(func, noarg, desc) should have the proper description
+ok 795 - is_window(func, noarg, desc) should have the proper diagnostics
+ok 796 - isnt_window(win, noargs, desc) should fail
+ok 797 - isnt_window(win, noargs, desc) should have the proper description
+ok 798 - isnt_window(win, noargs, desc) should have the proper diagnostics
+ok 799 - is_window(nowin, arg, desc) should fail
+ok 800 - is_window(nowin, arg, desc) should have the proper description
+ok 801 - is_window(nowin, arg, desc) should have the proper diagnostics
+ok 802 - isnt_window(nowin, arg, desc) should fail
+ok 803 - isnt_window(nowin, arg, desc) should have the proper description
+ok 804 - isnt_window(nowin, arg, desc) should have the proper diagnostics
+ok 805 - is_window(win, arg, desc) should pass
+ok 806 - is_window(win, arg, desc) should have the proper description
+ok 807 - is_window(win, arg, desc) should have the proper diagnostics
+ok 808 - isnt_window(win, arg, desc) should fail
+ok 809 - isnt_window(win, arg, desc) should have the proper description
+ok 810 - isnt_window(win, arg, desc) should have the proper diagnostics
+ok 811 - is_window(func, arg, desc) should fail
+ok 812 - is_window(func, arg, desc) should have the proper description
+ok 813 - is_window(func, arg, desc) should have the proper diagnostics
+ok 814 - isnt_window(func, arg, desc) should pass
+ok 815 - isnt_window(func, arg, desc) should have the proper description
+ok 816 - isnt_window(func, arg, desc) should have the proper diagnostics
+ok 817 - is_window(win, noargs, desc) should pass
+ok 818 - is_window(win, noargs, desc) should have the proper description
+ok 819 - is_window(win, noargs, desc) should have the proper diagnostics
+ok 820 - isnt_window(win, noargs, desc) should fail
+ok 821 - isnt_window(win, noargs, desc) should have the proper description
+ok 822 - isnt_window(win, noargs, desc) should have the proper diagnostics
+ok 823 - is_window(func, noarg, desc) should fail
+ok 824 - is_window(func, noarg, desc) should have the proper description
+ok 825 - is_window(func, noarg, desc) should have the proper diagnostics
+ok 826 - isnt_window(win, noargs, desc) should fail
+ok 827 - isnt_window(win, noargs, desc) should have the proper description
+ok 828 - isnt_window(win, noargs, desc) should have the proper diagnostics
+ok 829 - is_window(nowin, arg, desc) should fail
+ok 830 - is_window(nowin, arg, desc) should have the proper description
+ok 831 - is_window(nowin, arg, desc) should have the proper diagnostics
+ok 832 - isnt_window(nowin, arg, desc) should fail
+ok 833 - isnt_window(nowin, arg, desc) should have the proper description
+ok 834 - isnt_window(nowin, arg, desc) should have the proper diagnostics
+ok 835 - is_window(win, desc) should pass
+ok 836 - is_window(win, desc) should have the proper description
+ok 837 - is_window(win, desc) should have the proper diagnostics
+ok 838 - isnt_window(win, desc) should fail
+ok 839 - isnt_window(win, desc) should have the proper description
+ok 840 - isnt_window(win, desc) should have the proper diagnostics
+ok 841 - is_window(func, desc) should fail
+ok 842 - is_window(func, desc) should have the proper description
+ok 843 - is_window(func, desc) should have the proper diagnostics
+ok 844 - isnt_window(func, desc) should pass
+ok 845 - isnt_window(func, desc) should have the proper description
+ok 846 - isnt_window(func, desc) should have the proper diagnostics
+ok 847 - is_window(func, desc) should fail
+ok 848 - is_window(func, desc) should have the proper description
+ok 849 - is_window(func, desc) should have the proper diagnostics
+ok 850 - isnt_window(win, desc) should fail
+ok 851 - isnt_window(win, desc) should have the proper description
+ok 852 - isnt_window(win, desc) should have the proper diagnostics
+ok 853 - is_window(nowin, desc) should fail
+ok 854 - is_window(nowin, desc) should have the proper description
+ok 855 - is_window(nowin, desc) should have the proper diagnostics
+ok 856 - isnt_window(nowin, desc) should fail
+ok 857 - isnt_window(nowin, desc) should have the proper description
+ok 858 - isnt_window(nowin, desc) should have the proper diagnostics
+ok 859 - is_window(win) should pass
+ok 860 - is_window(win) should have the proper description
+ok 861 - is_window(win) should have the proper diagnostics
+ok 862 - isnt_window(win) should fail
+ok 863 - isnt_window(win) should have the proper description
+ok 864 - isnt_window(win) should have the proper diagnostics
+ok 865 - is_window(func) should fail
+ok 866 - is_window(func) should have the proper description
+ok 867 - is_window(func) should have the proper diagnostics
+ok 868 - isnt_window(func) should pass
+ok 869 - isnt_window(func) should have the proper description
+ok 870 - isnt_window(func) should have the proper diagnostics
+ok 871 - is_window(nowin) should fail
+ok 872 - is_window(nowin) should have the proper description
+ok 873 - is_window(nowin) should have the proper diagnostics
+ok 874 - isnt_window(nowin) should fail
+ok 875 - isnt_window(nowin) should have the proper description
+ok 876 - isnt_window(nowin) should have the proper diagnostics
+ok 877 - is_strict(schema, func, 0 args, desc) should pass
+ok 878 - is_strict(schema, func, 0 args, desc) should have the proper description
+ok 879 - is_strict(schema, func, 0 args, desc) should have the proper diagnostics
+ok 880 - isnt_strict(schema, func, 0 args, desc) should fail
+ok 881 - isnt_strict(schema, func, 0 args, desc) should have the proper description
+ok 882 - isnt_strict(schema, func, 0 args, desc) should have the proper diagnostics
+ok 883 - is_strict(schema, func, 0 args) should pass
+ok 884 - is_strict(schema, func, 0 args) should have the proper description
+ok 885 - is_strict(schema, func, 0 args) should have the proper diagnostics
+ok 886 - isnt_strict(schema, func, 0 args) should fail
+ok 887 - isnt_strict(schema, func, 0 args) should have the proper description
+ok 888 - isnt_strict(schema, func, 0 args) should have the proper diagnostics
+ok 889 - is_strict(schema, func, args, desc) should fail
+ok 890 - is_strict(schema, func, args, desc) should have the proper description
+ok 891 - is_strict(schema, func, args, desc) should have the proper diagnostics
+ok 892 - isnt_strict(schema, func, args, desc) should pass
+ok 893 - isnt_strict(schema, func, args, desc) should have the proper description
+ok 894 - isnt_strict(schema, func, args, desc) should have the proper diagnostics
+ok 895 - is_strict(schema, func, args) should fail
+ok 896 - is_strict(schema, func, args) should have the proper description
+ok 897 - is_strict(schema, func, args) should have the proper diagnostics
+ok 898 - isnt_strict(schema, func, args) should pass
+ok 899 - isnt_strict(schema, func, args) should have the proper description
+ok 900 - isnt_strict(schema, func, args) should have the proper diagnostics
+ok 901 - is_strict(schema, func, desc) should pass
+ok 902 - is_strict(schema, func, desc) should have the proper description
+ok 903 - is_strict(schema, func, desc) should have the proper diagnostics
+ok 904 - isnt_strict(schema, func, desc) should fail
+ok 905 - isnt_strict(schema, func, desc) should have the proper description
+ok 906 - isnt_strict(schema, func, desc) should have the proper diagnostics
+ok 907 - is_strict(schema, func) should pass
+ok 908 - is_strict(schema, func) should have the proper description
+ok 909 - is_strict(schema, func) should have the proper diagnostics
+ok 910 - isnt_strict(schema, func) should fail
+ok 911 - isnt_strict(schema, func) should have the proper description
+ok 912 - isnt_strict(schema, func) should have the proper diagnostics
+ok 913 - isnt_strict(schema, func, args, desc) should pass
+ok 914 - isnt_strict(schema, func, args, desc) should have the proper description
+ok 915 - isnt_strict(schema, func, args, desc) should have the proper diagnostics
+ok 916 - isnt_strict(schema, func, args) should pass
+ok 917 - isnt_strict(schema, func, args) should have the proper description
+ok 918 - isnt_strict(schema, func, args) should have the proper diagnostics
+ok 919 - is_strict(func, 0 args, desc) should pass
+ok 920 - is_strict(func, 0 args, desc) should have the proper description
+ok 921 - is_strict(func, 0 args, desc) should have the proper diagnostics
+ok 922 - isnt_strict(func, 0 args, desc) should fail
+ok 923 - isnt_strict(func, 0 args, desc) should have the proper description
+ok 924 - isnt_strict(func, 0 args, desc) should have the proper diagnostics
+ok 925 - is_strict(func, 0 args) should pass
+ok 926 - is_strict(func, 0 args) should have the proper description
+ok 927 - is_strict(func, 0 args) should have the proper diagnostics
+ok 928 - isnt_strict(func, 0 args) should fail
+ok 929 - isnt_strict(func, 0 args) should have the proper description
+ok 930 - isnt_strict(func, 0 args) should have the proper diagnostics
+ok 931 - is_strict(func, args, desc) should fail
+ok 932 - is_strict(func, args, desc) should have the proper description
+ok 933 - is_strict(func, args, desc) should have the proper diagnostics
+ok 934 - isnt_strict(func, args, desc) should pass
+ok 935 - isnt_strict(func, args, desc) should have the proper description
+ok 936 - isnt_strict(func, args, desc) should have the proper diagnostics
+ok 937 - is_strict(func, args) should fail
+ok 938 - is_strict(func, args) should have the proper description
+ok 939 - is_strict(func, args) should have the proper diagnostics
+ok 940 - isnt_strict(func, args) should pass
+ok 941 - isnt_strict(func, args) should have the proper description
+ok 942 - isnt_strict(func, args) should have the proper diagnostics
+ok 943 - is_strict(func, desc) should pass
+ok 944 - is_strict(func, desc) should have the proper description
+ok 945 - is_strict(func, desc) should have the proper diagnostics
+ok 946 - isnt_strict(func, desc) should fail
+ok 947 - isnt_strict(func, desc) should have the proper description
+ok 948 - isnt_strict(func, desc) should have the proper diagnostics
+ok 949 - is_strict(func) should pass
+ok 950 - is_strict(func) should have the proper description
+ok 951 - is_strict(func) should have the proper diagnostics
+ok 952 - isnt_strict(func) should fail
+ok 953 - isnt_strict(func) should have the proper description
+ok 954 - isnt_strict(func) should have the proper diagnostics
+ok 955 - function_volatility(schema, func, 0 args, volatile, desc) should pass
+ok 956 - function_volatility(schema, func, 0 args, volatile, desc) should have the proper description
+ok 957 - function_volatility(schema, func, 0 args, volatile, desc) should have the proper diagnostics
+ok 958 - function_volatility(schema, func, 0 args, v, desc) should pass
+ok 959 - function_volatility(schema, func, 0 args, v, desc) should have the proper description
+ok 960 - function_volatility(schema, func, 0 args, v, desc) should have the proper diagnostics
+ok 961 - function_volatility(schema, func, args, immutable, desc) should pass
+ok 962 - function_volatility(schema, func, args, immutable, desc) should have the proper description
+ok 963 - function_volatility(schema, func, args, immutable, desc) should have the proper diagnostics
+ok 964 - function_volatility(schema, func, 0 args, stable, desc) should pass
+ok 965 - function_volatility(schema, func, 0 args, stable, desc) should have the proper description
+ok 966 - function_volatility(schema, func, 0 args, stable, desc) should have the proper diagnostics
+ok 967 - function_volatility(schema, func, 0 args, volatile) should pass
+ok 968 - function_volatility(schema, func, 0 args, volatile) should have the proper description
+ok 969 - function_volatility(schema, func, 0 args, volatile) should have the proper diagnostics
+ok 970 - function_volatility(schema, func, args, immutable) should pass
+ok 971 - function_volatility(schema, func, args, immutable) should have the proper description
+ok 972 - function_volatility(schema, func, volatile, desc) should pass
+ok 973 - function_volatility(schema, func, volatile, desc) should have the proper description
+ok 974 - function_volatility(schema, func, volatile, desc) should have the proper diagnostics
+ok 975 - function_volatility(schema, func, volatile) should pass
+ok 976 - function_volatility(schema, func, volatile) should have the proper description
+ok 977 - function_volatility(schema, func, volatile) should have the proper diagnostics
+ok 978 - function_volatility(schema, func, immutable, desc) should pass
+ok 979 - function_volatility(schema, func, immutable, desc) should have the proper description
+ok 980 - function_volatility(schema, func, immutable, desc) should have the proper diagnostics
+ok 981 - function_volatility(schema, func, stable, desc) should pass
+ok 982 - function_volatility(schema, func, stable, desc) should have the proper description
+ok 983 - function_volatility(schema, func, stable, desc) should have the proper diagnostics
+ok 984 - function_volatility(func, 0 args, volatile, desc) should pass
+ok 985 - function_volatility(func, 0 args, volatile, desc) should have the proper description
+ok 986 - function_volatility(func, 0 args, volatile, desc) should have the proper diagnostics
+ok 987 - function_volatility(func, 0 args, v, desc) should pass
+ok 988 - function_volatility(func, 0 args, v, desc) should have the proper description
+ok 989 - function_volatility(func, 0 args, v, desc) should have the proper diagnostics
+ok 990 - function_volatility(func, args, immutable, desc) should pass
+ok 991 - function_volatility(func, args, immutable, desc) should have the proper description
+ok 992 - function_volatility(func, args, immutable, desc) should have the proper diagnostics
+ok 993 - function_volatility(func, 0 args, stable, desc) should pass
+ok 994 - function_volatility(func, 0 args, stable, desc) should have the proper description
+ok 995 - function_volatility(func, 0 args, stable, desc) should have the proper diagnostics
+ok 996 - function_volatility(func, 0 args, volatile) should pass
+ok 997 - function_volatility(func, 0 args, volatile) should have the proper description
+ok 998 - function_volatility(func, 0 args, volatile) should have the proper diagnostics
+ok 999 - function_volatility(func, args, immutable) should pass
+ok 1000 - function_volatility(func, args, immutable) should have the proper description
+ok 1001 - function_volatility(func, volatile, desc) should pass
+ok 1002 - function_volatility(func, volatile, desc) should have the proper description
+ok 1003 - function_volatility(func, volatile, desc) should have the proper diagnostics
+ok 1004 - function_volatility(func, volatile) should pass
+ok 1005 - function_volatility(func, volatile) should have the proper description
+ok 1006 - function_volatility(func, volatile) should have the proper diagnostics
+ok 1007 - function_volatility(func, immutable, desc) should pass
+ok 1008 - function_volatility(func, immutable, desc) should have the proper description
+ok 1009 - function_volatility(func, immutable, desc) should have the proper diagnostics
+ok 1010 - function_volatility(func, stable, desc) should pass
+ok 1011 - function_volatility(func, stable, desc) should have the proper description
+ok 1012 - function_volatility(func, stable, desc) should have the proper diagnostics

--- a/test/expected/proctap.out
+++ b/test/expected/proctap.out
@@ -1,0 +1,194 @@
+\unset ECHO
+1..192
+ok 1 - is_procedure(schema, proc, noargs, desc) should pass
+ok 2 - is_procedure(schema, proc, noargs, desc) should have the proper description
+ok 3 - is_procedure(schema, proc, noargs, desc) should have the proper diagnostics
+ok 4 - isnt_procedure(schema, proc, noargs, desc) should fail
+ok 5 - isnt_procedure(schema, proc, noargs, desc) should have the proper description
+ok 6 - isnt_procedure(schema, proc, noargs, desc) should have the proper diagnostics
+ok 7 - is_procedure(schema, func, noargs, desc) should fail
+ok 8 - is_procedure(schema, func, noargs, desc) should have the proper description
+ok 9 - is_procedure(schema, func, noargs, desc) should have the proper diagnostics
+ok 10 - isnt_procedure(schema, func, noargs, desc) should pass
+ok 11 - isnt_procedure(schema, func, noargs, desc) should have the proper description
+ok 12 - isnt_procedure(schema, func, noargs, desc) should have the proper diagnostics
+ok 13 - is_procedure(schema, proc, args, desc) should pass
+ok 14 - is_procedure(schema, proc, args, desc) should have the proper description
+ok 15 - is_procedure(schema, proc, args, desc) should have the proper diagnostics
+ok 16 - isnt_procedure(schema, proc, args, desc) should fail
+ok 17 - isnt_procedure(schema, proc, args, desc) should have the proper description
+ok 18 - isnt_procedure(schema, proc, args, desc) should have the proper diagnostics
+ok 19 - is_procedure(schema, func, args, desc) should fail
+ok 20 - is_procedure(schema, func, args, desc) should have the proper description
+ok 21 - is_procedure(schema, func, args, desc) should have the proper diagnostics
+ok 22 - isnt_procedure(schema, func, args, desc) should pass
+ok 23 - isnt_procedure(schema, func, args, desc) should have the proper description
+ok 24 - isnt_procedure(schema, func, args, desc) should have the proper diagnostics
+ok 25 - is_procedure(schema, noproc, noargs, desc) should fail
+ok 26 - is_procedure(schema, noproc, noargs, desc) should have the proper description
+ok 27 - is_procedure(schema, noproc, noargs, desc) should have the proper diagnostics
+ok 28 - isnt_procedure(schema, noproc, noargs, desc) should fail
+ok 29 - isnt_procedure(schema, noproc, noargs, desc) should have the proper description
+ok 30 - isnt_procedure(schema, noproc, noargs, desc) should have the proper diagnostics
+ok 31 - is_procedure(schema, proc, noargs) should pass
+ok 32 - is_procedure(schema, proc, noargs) should have the proper description
+ok 33 - is_procedure(schema, proc, noargs) should have the proper diagnostics
+ok 34 - isnt_procedure(schema, proc, noargs) should fail
+ok 35 - isnt_procedure(schema, proc, noargs) should have the proper description
+ok 36 - isnt_procedure(schema, proc, noargs) should have the proper diagnostics
+ok 37 - is_procedure(schema, func, noargs) should fail
+ok 38 - is_procedure(schema, func, noargs) should have the proper description
+ok 39 - is_procedure(schema, func, noargs) should have the proper diagnostics
+ok 40 - isnt_procedure(schema, func, noargs) should pass
+ok 41 - isnt_procedure(schema, func, noargs) should have the proper description
+ok 42 - isnt_procedure(schema, func, noargs) should have the proper diagnostics
+ok 43 - is_procedure(schema, proc, args) should pass
+ok 44 - is_procedure(schema, proc, args) should have the proper description
+ok 45 - is_procedure(schema, proc, args) should have the proper diagnostics
+ok 46 - isnt_procedure(schema, proc, args) should fail
+ok 47 - isnt_procedure(schema, proc, args) should have the proper description
+ok 48 - isnt_procedure(schema, proc, args) should have the proper diagnostics
+ok 49 - is_procedure(schema, func, args) should fail
+ok 50 - is_procedure(schema, func, args) should have the proper description
+ok 51 - is_procedure(schema, func, args) should have the proper diagnostics
+ok 52 - isnt_procedure(schema, func, args) should pass
+ok 53 - isnt_procedure(schema, func, args) should have the proper description
+ok 54 - isnt_procedure(schema, func, args) should have the proper diagnostics
+ok 55 - is_procedure(schema, noproc, noargs) should fail
+ok 56 - is_procedure(schema, noproc, noargs) should have the proper description
+ok 57 - is_procedure(schema, noproc, noargs) should have the proper diagnostics
+ok 58 - isnt_procedure(schema, noproc, noargs) should fail
+ok 59 - isnt_procedure(schema, noproc, noargs) should have the proper description
+ok 60 - isnt_procedure(schema, noproc, noargs) should have the proper diagnostics
+ok 61 - is_procedure(schema, proc, desc) should pass
+ok 62 - is_procedure(schema, proc, desc) should have the proper description
+ok 63 - is_procedure(schema, proc, desc) should have the proper diagnostics
+ok 64 - isnt_procedure(schema, proc, desc) should fail
+ok 65 - isnt_procedure(schema, proc, desc) should have the proper description
+ok 66 - isnt_procedure(schema, proc, desc) should have the proper diagnostics
+ok 67 - is_procedure(schema, func, desc) should fail
+ok 68 - is_procedure(schema, func, desc) should have the proper description
+ok 69 - is_procedure(schema, func, desc) should have the proper diagnostics
+ok 70 - isnt_procedure(schema, func, desc) should pass
+ok 71 - isnt_procedure(schema, func, desc) should have the proper description
+ok 72 - isnt_procedure(schema, func, desc) should have the proper diagnostics
+ok 73 - is_procedure(schema, noproc, desc) should fail
+ok 74 - is_procedure(schema, noproc, desc) should have the proper description
+ok 75 - is_procedure(schema, noproc, desc) should have the proper diagnostics
+ok 76 - isnt_procedure(schema, noproc, desc) should fail
+ok 77 - isnt_procedure(schema, noproc, desc) should have the proper description
+ok 78 - isnt_procedure(schema, noproc, desc) should have the proper diagnostics
+ok 79 - is_procedure(schema, proc) should pass
+ok 80 - is_procedure(schema, proc) should have the proper description
+ok 81 - is_procedure(schema, proc) should have the proper diagnostics
+ok 82 - isnt_procedure(schema, proc) should fail
+ok 83 - isnt_procedure(schema, proc) should have the proper description
+ok 84 - isnt_procedure(schema, proc) should have the proper diagnostics
+ok 85 - is_procedure(schema, func) should fail
+ok 86 - is_procedure(schema, func) should have the proper description
+ok 87 - is_procedure(schema, func) should have the proper diagnostics
+ok 88 - isnt_procedure(schema, func) should pass
+ok 89 - isnt_procedure(schema, func) should have the proper description
+ok 90 - isnt_procedure(schema, func) should have the proper diagnostics
+ok 91 - is_procedure(schema, noproc) should fail
+ok 92 - is_procedure(schema, noproc) should have the proper description
+ok 93 - is_procedure(schema, noproc) should have the proper diagnostics
+ok 94 - isnt_procedure(schema, noproc) should fail
+ok 95 - isnt_procedure(schema, noproc) should have the proper description
+ok 96 - isnt_procedure(schema, noproc) should have the proper diagnostics
+ok 97 - is_procedure(proc, noargs, desc) should pass
+ok 98 - is_procedure(proc, noargs, desc) should have the proper description
+ok 99 - is_procedure(proc, noargs, desc) should have the proper diagnostics
+ok 100 - isnt_procedure(proc, noargs, desc) should fail
+ok 101 - isnt_procedure(proc, noargs, desc) should have the proper description
+ok 102 - isnt_procedure(proc, noargs, desc) should have the proper diagnostics
+ok 103 - is_procedure(func, noargs, desc) should fail
+ok 104 - is_procedure(func, noargs, desc) should have the proper description
+ok 105 - is_procedure(func, noargs, desc) should have the proper diagnostics
+ok 106 - isnt_procedure(schema, func, noargs, desc) should pass
+ok 107 - isnt_procedure(schema, func, noargs, desc) should have the proper description
+ok 108 - isnt_procedure(schema, func, noargs, desc) should have the proper diagnostics
+ok 109 - is_procedure(proc, args, desc) should pass
+ok 110 - is_procedure(proc, args, desc) should have the proper description
+ok 111 - is_procedure(proc, args, desc) should have the proper diagnostics
+ok 112 - isnt_procedure(proc, args, desc) should fail
+ok 113 - isnt_procedure(proc, args, desc) should have the proper description
+ok 114 - isnt_procedure(proc, args, desc) should have the proper diagnostics
+ok 115 - is_procedure(unc, args, desc) should fail
+ok 116 - is_procedure(unc, args, desc) should have the proper description
+ok 117 - is_procedure(unc, args, desc) should have the proper diagnostics
+ok 118 - isnt_procedure(func, args, desc) should pass
+ok 119 - isnt_procedure(func, args, desc) should have the proper description
+ok 120 - isnt_procedure(func, args, desc) should have the proper diagnostics
+ok 121 - is_procedure(noproc, noargs, desc) should fail
+ok 122 - is_procedure(noproc, noargs, desc) should have the proper description
+ok 123 - is_procedure(noproc, noargs, desc) should have the proper diagnostics
+ok 124 - isnt_procedure(noproc, noargs, desc) should fail
+ok 125 - isnt_procedure(noproc, noargs, desc) should have the proper description
+ok 126 - isnt_procedure(noproc, noargs, desc) should have the proper diagnostics
+ok 127 - is_procedure(proc, noargs) should pass
+ok 128 - is_procedure(proc, noargs) should have the proper description
+ok 129 - is_procedure(proc, noargs) should have the proper diagnostics
+ok 130 - isnt_procedure(proc, noargs) should fail
+ok 131 - isnt_procedure(proc, noargs) should have the proper description
+ok 132 - isnt_procedure(proc, noargs) should have the proper diagnostics
+ok 133 - is_procedure(func, noargs) should fail
+ok 134 - is_procedure(func, noargs) should have the proper description
+ok 135 - is_procedure(func, noargs) should have the proper diagnostics
+ok 136 - isnt_procedure(schema, func, noargs) should pass
+ok 137 - isnt_procedure(schema, func, noargs) should have the proper description
+ok 138 - isnt_procedure(schema, func, noargs) should have the proper diagnostics
+ok 139 - is_procedure(proc, args) should pass
+ok 140 - is_procedure(proc, args) should have the proper description
+ok 141 - is_procedure(proc, args) should have the proper diagnostics
+ok 142 - isnt_procedure(proc, args) should fail
+ok 143 - isnt_procedure(proc, args) should have the proper description
+ok 144 - isnt_procedure(proc, args) should have the proper diagnostics
+ok 145 - is_procedure(unc, args) should fail
+ok 146 - is_procedure(unc, args) should have the proper description
+ok 147 - is_procedure(unc, args) should have the proper diagnostics
+ok 148 - isnt_procedure(func, args) should pass
+ok 149 - isnt_procedure(func, args) should have the proper description
+ok 150 - isnt_procedure(func, args) should have the proper diagnostics
+ok 151 - is_procedure(noproc, noargs) should fail
+ok 152 - is_procedure(noproc, noargs) should have the proper description
+ok 153 - is_procedure(noproc, noargs) should have the proper diagnostics
+ok 154 - isnt_procedure(noproc, noargs) should fail
+ok 155 - isnt_procedure(noproc, noargs) should have the proper description
+ok 156 - isnt_procedure(noproc, noargs) should have the proper diagnostics
+ok 157 - is_procedure(proc, desc) should pass
+ok 158 - is_procedure(proc, desc) should have the proper description
+ok 159 - is_procedure(proc, desc) should have the proper diagnostics
+ok 160 - isnt_procedure(proc, desc) should fail
+ok 161 - isnt_procedure(proc, desc) should have the proper description
+ok 162 - isnt_procedure(proc, desc) should have the proper diagnostics
+ok 163 - is_procedure(func, desc) should fail
+ok 164 - is_procedure(func, desc) should have the proper description
+ok 165 - is_procedure(func, desc) should have the proper diagnostics
+ok 166 - isnt_procedure(func, desc) should pass
+ok 167 - isnt_procedure(func, desc) should have the proper description
+ok 168 - isnt_procedure(func, desc) should have the proper diagnostics
+ok 169 - is_procedure(noproc, desc) should fail
+ok 170 - is_procedure(noproc, desc) should have the proper description
+ok 171 - is_procedure(noproc, desc) should have the proper diagnostics
+ok 172 - isnt_procedure(noproc, desc) should fail
+ok 173 - isnt_procedure(noproc, desc) should have the proper description
+ok 174 - isnt_procedure(noproc, desc) should have the proper diagnostics
+ok 175 - is_procedure(proc) should pass
+ok 176 - is_procedure(proc) should have the proper description
+ok 177 - is_procedure(proc) should have the proper diagnostics
+ok 178 - isnt_procedure(proc) should fail
+ok 179 - isnt_procedure(proc) should have the proper description
+ok 180 - isnt_procedure(proc) should have the proper diagnostics
+ok 181 - is_procedure(func) should fail
+ok 182 - is_procedure(func) should have the proper description
+ok 183 - is_procedure(func) should have the proper diagnostics
+ok 184 - isnt_procedure(func) should pass
+ok 185 - isnt_procedure(func) should have the proper description
+ok 186 - isnt_procedure(func) should have the proper diagnostics
+ok 187 - is_procedure(noproc) should fail
+ok 188 - is_procedure(noproc) should have the proper description
+ok 189 - is_procedure(noproc) should have the proper diagnostics
+ok 190 - isnt_procedure(noproc) should fail
+ok 191 - isnt_procedure(noproc) should have the proper description
+ok 192 - isnt_procedure(noproc) should have the proper diagnostics

--- a/test/sql/proctap.sql
+++ b/test/sql/proctap.sql
@@ -1,0 +1,560 @@
+\unset ECHO
+\i test/setup.sql
+
+SELECT plan(192);
+-- SELECT * FROM no_plan();
+
+CREATE SCHEMA procschema;
+CREATE FUNCTION procschema.afunc() RETURNS BOOL AS 'SELECT TRUE' LANGUAGE SQL;
+CREATE FUNCTION procschema.argfunc(int, text) RETURNS BOOL AS 'SELECT TRUE' LANGUAGE SQL;
+
+CREATE PROCEDURE procschema.aproc() AS 'SELECT TRUE' LANGUAGE SQL;
+CREATE PROCEDURE procschema.argproc(int, text) AS 'SELECT TRUE' LANGUAGE SQL;
+
+CREATE FUNCTION public.pubfunc() RETURNS BOOL AS 'SELECT TRUE' LANGUAGE SQL;
+CREATE FUNCTION public.argpubfunc(int, text) RETURNS BOOL AS 'SELECT TRUE' LANGUAGE SQL;
+
+CREATE PROCEDURE public.pubproc() AS 'SELECT TRUE' LANGUAGE SQL;
+CREATE PROCEDURE public.argpubproc(int, text) AS 'SELECT TRUE' LANGUAGE SQL;
+
+-- is_procedure ( NAME, NAME, NAME[], TEXT )
+-- isnt_procedure ( NAME, NAME, NAME[], TEXT )
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'aproc', '{}'::name[], 'whatever' ),
+    true,
+    'is_procedure(schema, proc, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'aproc', '{}'::name[], 'whatever' ),
+    false,
+    'isnt_procedure(schema, proc, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'afunc', '{}'::name[], 'whatever' ),
+    false,
+    'is_procedure(schema, func, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'afunc', '{}'::name[], 'whatever' ),
+    true,
+    'isnt_procedure(schema, func, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argproc', ARRAY['integer', 'text'], 'whatever' ),
+    true,
+    'is_procedure(schema, proc, args, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argproc', ARRAY['integer', 'text'], 'whatever' ),
+    false,
+    'isnt_procedure(schema, proc, args, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argfunc', ARRAY['integer', 'text'], 'whatever' ),
+    false,
+    'is_procedure(schema, func, args, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argfunc', ARRAY['integer', 'text'], 'whatever' ),
+    true,
+    'isnt_procedure(schema, func, args, desc)',
+    'whatever',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'nope', '{}'::name[], 'whatever' ),
+    false,
+    'is_procedure(schema, noproc, noargs, desc)',
+    'whatever',
+    '    Function procschema.nope() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'nope', '{}'::name[], 'whatever' ),
+    false,
+    'isnt_procedure(schema, noproc, noargs, desc)',
+    'whatever',
+    '    Function procschema.nope() does not exist'
+);
+
+-- is_procedure( NAME, NAME, NAME[] )
+-- isnt_procedure( NAME, NAME, NAME[] )
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'aproc', '{}'::name[] ),
+    true,
+    'is_procedure(schema, proc, noargs)',
+    'Function procschema.aproc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'aproc', '{}'::name[] ),
+    false,
+    'isnt_procedure(schema, proc, noargs)',
+    'Function procschema.aproc() should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'afunc', '{}'::name[] ),
+    false,
+    'is_procedure(schema, func, noargs)',
+    'Function procschema.afunc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'afunc', '{}'::name[] ),
+    true,
+    'isnt_procedure(schema, func, noargs)',
+    'Function procschema.afunc() should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argproc', ARRAY['integer', 'text'] ),
+    true,
+    'is_procedure(schema, proc, args)',
+    'Function procschema.argproc(integer, text) should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argproc', ARRAY['integer', 'text'] ),
+    false,
+    'isnt_procedure(schema, proc, args)',
+    'Function procschema.argproc(integer, text) should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argfunc', ARRAY['integer', 'text'] ),
+    false,
+    'is_procedure(schema, func, args)',
+    'Function procschema.argfunc(integer, text) should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argfunc', ARRAY['integer', 'text'] ),
+    true,
+    'isnt_procedure(schema, func, args)',
+    'Function procschema.argfunc(integer, text) should not be a procedure',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'nada', '{}'::name[] ),
+    false,
+    'is_procedure(schema, noproc, noargs)',
+    'Function procschema.nada() should be a procedure',
+    '    Function procschema.nada() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'nada', '{}'::name[] ),
+    false,
+    'isnt_procedure(schema, noproc, noargs)',
+    'Function procschema.nada() should not be a procedure',
+    '    Function procschema.nada() does not exist'
+);
+
+-- is_procedure ( NAME, NAME, TEXT )
+-- isnt_procedure ( NAME, NAME, TEXT )
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argproc', 'whatever' ),
+    true,
+    'is_procedure(schema, proc, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argproc', 'whatever' ),
+    false,
+    'isnt_procedure(schema, proc, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argfunc', 'whatever' ),
+    false,
+    'is_procedure(schema, func, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argfunc', 'whatever' ),
+    true,
+    'isnt_procedure(schema, func, desc)',
+    'whatever',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'nork', 'whatever' ),
+    false,
+    'is_procedure(schema, noproc, desc)',
+    'whatever',
+    '    Function procschema.nork() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'nork', 'whatever' ),
+    false,
+    'isnt_procedure(schema, noproc, desc)',
+    'whatever',
+    '    Function procschema.nork() does not exist'
+);
+
+-- is_procedure( NAME, NAME )
+-- isnt_procedure( NAME, NAME )
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argproc'::name ),
+    true,
+    'is_procedure(schema, proc)',
+    'Function procschema.argproc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argproc'::name ),
+    false,
+    'isnt_procedure(schema, proc)',
+    'Function procschema.argproc() should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'argfunc'::name ),
+    false,
+    'is_procedure(schema, func)',
+    'Function procschema.argfunc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'argfunc'::name ),
+    true,
+    'isnt_procedure(schema, func)',
+    'Function procschema.argfunc() should not be a procedure',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'procschema', 'zippo'::name ),
+    false,
+    'is_procedure(schema, noproc)',
+    'Function procschema.zippo() should be a procedure',
+    '    Function procschema.zippo() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'procschema', 'zippo'::name ),
+    false,
+    'isnt_procedure(schema, noproc)',
+    'Function procschema.zippo() should not be a procedure',
+    '    Function procschema.zippo() does not exist'
+);
+
+
+-- is_procedure ( NAME, NAME[], TEXT )
+-- isnt_procedure ( NAME, NAME[], TEXT )
+SELECT * FROM check_test(
+    is_procedure( 'pubproc', '{}'::name[], 'whatever' ),
+    true,
+    'is_procedure(proc, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'pubproc', '{}'::name[], 'whatever' ),
+    false,
+    'isnt_procedure(proc, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'pubfunc', '{}'::name[], 'whatever' ),
+    false,
+    'is_procedure(func, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'pubfunc', '{}'::name[], 'whatever' ),
+    true,
+    'isnt_procedure(schema, func, noargs, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'argpubproc', ARRAY['integer', 'text'], 'whatever' ),
+    true,
+    'is_procedure(proc, args, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubproc', ARRAY['integer', 'text'], 'whatever' ),
+    false,
+    'isnt_procedure(proc, args, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'argpubfunc', ARRAY['integer', 'text'], 'whatever' ),
+    false,
+    'is_procedure(unc, args, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubfunc', ARRAY['integer', 'text'], 'whatever' ),
+    true,
+    'isnt_procedure(func, args, desc)',
+    'whatever',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'nonesuch', '{}'::name[], 'whatever' ),
+    false,
+    'is_procedure(noproc, noargs, desc)',
+    'whatever',
+    '    Function nonesuch() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'nonesuch', '{}'::name[], 'whatever' ),
+    false,
+    'isnt_procedure(noproc, noargs, desc)',
+    'whatever',
+    '    Function nonesuch() does not exist'
+);
+
+-- is_procedure( NAME, NAME[] )
+-- isnt_procedure( NAME, NAME[] )
+SELECT * FROM check_test(
+    is_procedure( 'pubproc', '{}'::name[] ),
+    true,
+    'is_procedure(proc, noargs)',
+    'Function pubproc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'pubproc', '{}'::name[] ),
+    false,
+    'isnt_procedure(proc, noargs)',
+    'Function pubproc() should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'pubfunc', '{}'::name[] ),
+    false,
+    'is_procedure(func, noargs)',
+    'Function pubfunc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'pubfunc', '{}'::name[] ),
+    true,
+    'isnt_procedure(schema, func, noargs)',
+    'Function pubfunc() should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'argpubproc', ARRAY['integer', 'text'] ),
+    true,
+    'is_procedure(proc, args)',
+    'Function argpubproc(integer, text) should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubproc', ARRAY['integer', 'text'] ),
+    false,
+    'isnt_procedure(proc, args)',
+    'Function argpubproc(integer, text) should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'argpubfunc', ARRAY['integer', 'text'] ),
+    false,
+    'is_procedure(unc, args)',
+    'Function argpubfunc(integer, text) should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubfunc', ARRAY['integer', 'text'] ),
+    true,
+    'isnt_procedure(func, args)',
+    'Function argpubfunc(integer, text) should not be a procedure',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'nix', '{}'::name[] ),
+    false,
+    'is_procedure(noproc, noargs)',
+    'Function nix() should be a procedure',
+    '    Function nix() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'nix', '{}'::name[] ),
+    false,
+    'isnt_procedure(noproc, noargs)',
+    'Function nix() should not be a procedure',
+    '    Function nix() does not exist'
+);
+
+-- is_procedure( NAME, TEXT )
+-- isnt_procedure( NAME, TEXT )
+SELECT * FROM check_test(
+    is_procedure( 'argpubproc', 'whatever' ),
+    true,
+    'is_procedure(proc, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubproc', 'whatever' ),
+    false,
+    'isnt_procedure(proc, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'argpubfunc', 'whatever' ),
+    false,
+    'is_procedure(func, desc)',
+    'whatever',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubfunc', 'whatever' ),
+    true,
+    'isnt_procedure(func, desc)',
+    'whatever',
+    ''
+);
+
+-- Test diagnostics
+SELECT * FROM check_test(
+    is_procedure( 'zilch', 'whatever' ),
+    false,
+    'is_procedure(noproc, desc)',
+    'whatever',
+    '    Function zilch() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'zilch', 'whatever' ),
+    false,
+    'isnt_procedure(noproc, desc)',
+    'whatever',
+    '    Function zilch() does not exist'
+);
+
+-- is_procedure( NAME )
+-- isnt_procedure( NAME )
+SELECT * FROM check_test(
+    is_procedure( 'argpubproc' ),
+    true,
+    'is_procedure(proc)',
+    'Function argpubproc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubproc' ),
+    false,
+    'isnt_procedure(proc)',
+    'Function argpubproc() should not be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    is_procedure( 'argpubfunc' ),
+    false,
+    'is_procedure(func)',
+    'Function argpubfunc() should be a procedure',
+    ''
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'argpubfunc' ),
+    true,
+    'isnt_procedure(func)',
+    'Function argpubfunc() should not be a procedure',
+    ''
+);
+
+-- Test diagnosics
+SELECT * FROM check_test(
+    is_procedure( 'nope' ),
+    false,
+    'is_procedure(noproc)',
+    'Function nope() should be a procedure',
+    '    Function nope() does not exist'
+);
+
+SELECT * FROM check_test(
+    isnt_procedure( 'nope' ),
+    false,
+    'isnt_procedure(noproc)',
+    'Function nope() should not be a procedure',
+    '    Function nope() does not exist'
+);
+
+/****************************************************************************/
+-- Finish the tests and clean up.
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Previously we had `is_aggregate()` and `isnt_aggregate()`. Extend that model with these new functions:

*   `is_normal_function()`
*   `isnt_normal_function()`
*   `is_window()`
*   `isnt_window()`
*   `is_procedure()`
*   `isnt_procedure()`

Procedures are not supported on Postgres 10 and earlier, so we don't test them on those versions. Also update `is_aggregate()` and `isnt_aggregate()` to consistently output diagnostics for nonexistent functions, and test those
diagnostics (and do the same for the new functions, of course). Resolves #280.

Also, update `gencore` with the new functions, plus some changes that have been missed in the past (does anyone even use `pgtap-core.sql` or `pgtap-schema.sql`?).