### PR TITLE
Just use Perl to create uninstall script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ ifeq ($(shell echo $(VERSION) | grep -qE "^(9[.][012]|8[.][1234])" && echo yes |
 endif
 
 sql/uninstall_pgtap.sql: sql/pgtap.sql test/setup.sql
-	grep '^CREATE ' sql/pgtap.sql | $(PERL) -e 'for (reverse <STDIN>) { chomp; s/CREATE (OR REPLACE )?/DROP /; print "$$_;\n" }' | sed 's/DROP \(FUNCTION\|VIEW\|TYPE\) /DROP \1 IF EXISTS /' | sed -E 's/ (DEFAULT|=)[ ]+[a-zA-Z0-9]+//g' > sql/uninstall_pgtap.sql
+	$(PERL) -e 'for (grep { /^CREATE /} reverse <>) { chomp; s/CREATE (OR REPLACE )?/DROP /; s/DROP (FUNCTION|VIEW|TYPE) /DROP $$1 IF EXISTS /; s/ (DEFAULT|=)[ ]+[a-zA-Z0-9]+//g; print "$$_;\n" }' $< > $@
 
 #
 # Support for static install files


### PR DESCRIPTION
Rather than Perl plus two calls to `sed`. Seems like sometimes `sed` doesn't do all that we need it too, and we were already using Perl, so just move the replacement expressions into Perl loop. Fixes #270.