### PR TITLE
Unindent subtest diag header

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,11 @@ Revision history for pgTAP
   the analysis.
 * Fixed a pluralization error reporting xUnit test failures to report "failed 1
   test" instead of "failed 1 tests".
+* Removed the indentation for diagnostic comments at the start of subtests to
+  make it easier to see where they start and end. This changes the output
+  format, which will not affect tests run by `pg_prove`, but will break tests
+  that depend on diffing files, as `pg_regress` does. Thanks to Matt DeLuco for
+  highlighting the visual confusion of the indented diagnostic (#264).
 
 1.2.0 2021-12-05T18:08:13Z
 --------------------------

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -8411,11 +8411,11 @@ The output, assuming a single startup test, two subtests, and a single
 shutdown test, will look something like this:
 
     ok 1 - Startup test
-        # Subtest: public.test_this()
+    # Subtest: public.test_this()
         ok 1 - simple pass
         ok 2 - another simple pass
     ok 2 - public.test_this()
-        # Subtest: public.test_that()
+    # Subtest: public.test_that()
         ok 1 - that simple
         ok 2 - that simple 2
     ok 3 - public.test_that()

--- a/sql/pgtap--1.2.0--1.2.1.sql
+++ b/sql/pgtap--1.2.0--1.2.1.sql
@@ -29,7 +29,7 @@ BEGIN
     FOR i IN 1..COALESCE(array_upper(tests, 1), 0) LOOP
 
         -- What subtest are we running?
-        RETURN NEXT '    ' || diag_test_name('Subtest: ' || tests[i]);
+        RETURN NEXT diag_test_name('Subtest: ' || tests[i]);
 
         -- Reset the results.
         tok := TRUE;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -6567,7 +6567,7 @@ BEGIN
     FOR i IN 1..COALESCE(array_upper(tests, 1), 0) LOOP
 
         -- What subtest are we running?
-        RETURN NEXT '    ' || diag_test_name('Subtest: ' || tests[i]);
+        RETURN NEXT diag_test_name('Subtest: ' || tests[i]);
 
         -- Reset the results.
         tok := TRUE;

--- a/test/expected/runjusttests.out
+++ b/test/expected/runjusttests.out
@@ -1,21 +1,21 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: P0001: This test should die, but not halt execution.
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
     #         DETAIL:     DETAIL
@@ -32,12 +32,12 @@ ok 3 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -45,7 +45,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runjusttests_1.out
+++ b/test/expected/runjusttests_1.out
@@ -1,21 +1,21 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: P0001: This test should die, but not halt execution.
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
     #         DETAIL:     DETAIL
@@ -32,12 +32,12 @@ ok 3 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -45,7 +45,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runjusttests_2.out
+++ b/test/expected/runjusttests_2.out
@@ -1,21 +1,21 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: P0001: This test should die, but not halt execution.
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
     #         DETAIL:     DETAIL
@@ -27,12 +27,12 @@ ok 3 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -40,7 +40,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runjusttests_3.out
+++ b/test/expected/runjusttests_3.out
@@ -1,21 +1,21 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: P0001: This test should die, but not halt execution.
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
     #         DETAIL:     DETAIL
@@ -27,12 +27,12 @@ ok 3 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -40,7 +40,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runjusttests_4.out
+++ b/test/expected/runjusttests_4.out
@@ -1,31 +1,31 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: P0001: This test should die, but not halt execution.
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -33,7 +33,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runjusttests_5.out
+++ b/test/expected/runjusttests_5.out
@@ -1,21 +1,21 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: P0001: This test should die, but not halt execution.
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
     #         DETAIL:     DETAIL
@@ -33,12 +33,12 @@ ok 3 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -46,7 +46,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runjusttests_6.out
+++ b/test/expected/runjusttests_6.out
@@ -1,31 +1,31 @@
 \unset ECHO
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - ident
     ok 2 - ident 2
     1..2
 ok 1 - whatever."test ident"
-    # Subtest: whatever.testnada()
+# Subtest: whatever.testnada()
     1..0
     # No tests run!
 not ok 2 - whatever.testnada
 # Failed test 2: "whatever.testnada"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - plpgsql simple
     ok 2 - plpgsql simple 2
     ok 3 - Should be a 1 in the test table
     1..3
 ok 3 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     # Test died: This test should die, but not halt execution.
 # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
 not ok 4 - whatever.testplpgsqldie
 # Failed test 4: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - simple pass
     ok 2 - another simple pass
     1..2
 ok 5 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - pass
     not ok 2 - this test intentionally fails
     # Failed test 2: "this test intentionally fails"
@@ -33,7 +33,7 @@ ok 5 - whatever.testthis
     # Looks like you failed 1 test of 2
 not ok 6 - whatever.testy
 # Failed test 6: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - Late test should find nothing in the test table
     1..1
 ok 7 - whatever.testz

--- a/test/expected/runnotests.out
+++ b/test/expected/runnotests.out
@@ -1,5 +1,5 @@
 \unset ECHO
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     1..0
     # No tests run!
 not ok 1 - whatever.testthis

--- a/test/expected/runtests.out
+++ b/test/expected/runtests.out
@@ -1,7 +1,7 @@
 \unset ECHO
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -11,7 +11,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -23,7 +23,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -34,7 +34,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -55,7 +55,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -65,7 +65,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -77,7 +77,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -92,7 +92,7 @@ ok 11 - shutting down more
 # Looks like you failed 3 tests of 11
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -102,7 +102,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -113,7 +113,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -124,7 +124,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -144,7 +144,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -154,7 +154,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -166,7 +166,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more

--- a/test/expected/runtests_1.out
+++ b/test/expected/runtests_1.out
@@ -1,7 +1,7 @@
 \unset ECHO
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -11,7 +11,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -23,7 +23,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -34,7 +34,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -54,7 +54,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -64,7 +64,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -76,7 +76,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -91,7 +91,7 @@ ok 11 - shutting down more
 # Looks like you failed 3 tests of 11
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -101,7 +101,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -112,7 +112,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -123,7 +123,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -142,7 +142,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -152,7 +152,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -164,7 +164,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more

--- a/test/expected/runtests_2.out
+++ b/test/expected/runtests_2.out
@@ -1,7 +1,7 @@
 \unset ECHO
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -11,7 +11,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -23,7 +23,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -34,7 +34,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -54,7 +54,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -64,7 +64,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -76,7 +76,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -91,7 +91,7 @@ ok 11 - shutting down more
 # Looks like you failed 3 tests of 11
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -101,7 +101,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -112,7 +112,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -123,7 +123,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -142,7 +142,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -152,7 +152,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -164,7 +164,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more

--- a/test/expected/runtests_3.out
+++ b/test/expected/runtests_3.out
@@ -1,7 +1,7 @@
 \unset ECHO
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -11,7 +11,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -23,7 +23,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -34,7 +34,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -49,7 +49,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -59,7 +59,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -71,7 +71,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -86,7 +86,7 @@ ok 11 - shutting down more
 # Looks like you failed 3 tests of 11
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -96,7 +96,7 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -107,7 +107,7 @@ ok 3 - whatever."test ident"
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -118,7 +118,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -132,7 +132,7 @@ ok 5 - whatever.testplpgsql
     #             SQL function "runtests" statement 1
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -142,7 +142,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -154,7 +154,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more

--- a/test/expected/runtests_4.out
+++ b/test/expected/runtests_4.out
@@ -1,7 +1,7 @@
 \unset ECHO
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -11,14 +11,14 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
     # Test died: 22012: division by zero
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -29,7 +29,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -37,7 +37,7 @@ ok 5 - whatever.testplpgsql
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -47,7 +47,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -59,7 +59,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -74,7 +74,7 @@ ok 11 - shutting down more
 # Looks like you failed 3 tests of 11
 ok 1 - starting up
 ok 2 - starting up some more
-    # Subtest: whatever."test ident"()
+# Subtest: whatever."test ident"()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -84,14 +84,14 @@ ok 2 - starting up some more
     ok 7 - teardown more
     1..7
 ok 3 - whatever."test ident"
-    # Subtest: whatever.testdividebyzero()
+# Subtest: whatever.testdividebyzero()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
     # Test died: 22012: division by zero
 not ok 4 - whatever.testdividebyzero
 # Failed test 4: "whatever.testdividebyzero"
-    # Subtest: whatever.testplpgsql()
+# Subtest: whatever.testplpgsql()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -102,7 +102,7 @@ not ok 4 - whatever.testdividebyzero
     ok 8 - teardown more
     1..8
 ok 5 - whatever.testplpgsql
-    # Subtest: whatever.testplpgsqldie()
+# Subtest: whatever.testplpgsqldie()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -110,7 +110,7 @@ ok 5 - whatever.testplpgsql
     # Note that in some cases we get what appears to be a duplicate context message, but that is due to Postgres itself.
 not ok 6 - whatever.testplpgsqldie
 # Failed test 6: "whatever.testplpgsqldie"
-    # Subtest: whatever.testthis()
+# Subtest: whatever.testthis()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -120,7 +120,7 @@ not ok 6 - whatever.testplpgsqldie
     ok 7 - teardown more
     1..7
 ok 7 - whatever.testthis
-    # Subtest: whatever.testy()
+# Subtest: whatever.testy()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more
@@ -132,7 +132,7 @@ ok 7 - whatever.testthis
     # Looks like you failed 1 test of 6
 not ok 8 - whatever.testy
 # Failed test 8: "whatever.testy"
-    # Subtest: whatever.testz()
+# Subtest: whatever.testz()
     ok 1 - setup
     ok 2 - Should be nothing in the test table
     ok 3 - setup more


### PR DESCRIPTION
In order to make it clearer where a subest starts. This contrasts with how Test::More does it, but is easier to read for errors and aligns with how some other TAP frameworks like node tap do it. The format change will have no impact on how TAP-parsing tools like `pg_prove` interpret test output, but could break diff-based tooling such as `pg_regress`. That change is demonstrated in the expected files modified in this commit.

Resolves #264.