### PR TITLE
Update type-testing and function-testing functions to support short type names

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,11 @@ Revision history for pgTAP
   and `boolean`. The return value argument to `function_returns` and and data
   type tests such as `col_type_is` and `cast_context_is` must still use full
   type names. Thanks to @wphilips53 for the suggestion (#292).
+* Updated type-testing functions to allow short names for types, and updated
+  function-testing functions to allow short names for argument types. This means
+  that common aliases for standard types can be specified as, e.g., `int` and
+  `bool` rather than `integer` and `boolean`. Thanks to @wphilips53 for the
+  suggestion (#292).
 
 1.2.0 2021-12-05T18:08:13Z
 --------------------------

--- a/Changes
+++ b/Changes
@@ -29,6 +29,11 @@ Revision history for pgTAP
 * Fixed `LIKE` expression in `schemas_are()` to escape the underscore wildcard,
   making it `pg\_%` instead of `pg_%`. Thanks to Jehan-Guillaume (ioguix) de
   Rorthais for the PR (#311)!
+* Updated function-testing functions to allow short names for argument types, so
+  that they can be specified as, e.g., `int` and `bool` rather than `integer`
+  and `boolean`. The return value argument to `function_returns` and and data
+  type tests such as `col_type_is` and `cast_context_is` must still use full
+  type names. Thanks to @wphilips53 for the suggestion (#292).
 
 1.2.0 2021-12-05T18:08:13Z
 --------------------------
@@ -444,7 +449,7 @@ Revision history for pgTAP
 0.24 2010-05-24T23:33:22Z
 --------------------------
 * Got `sql/artap.sql` tests passing again when building with `$TAPSCHEMA` set.
-* Changed to saner source URL in `contrib/pgtap.spec`.
+* Changed to nicer source URL in `contrib/pgtap.spec`.
 * Fixed a bug in `has_member()` where it failed to confirm that users were
   actually members of a group.
 * Fixed a bug where `display_type()` would include the schema name in its

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -3733,14 +3733,8 @@ regard to its arguments. Some examples:
     );
 
     SELECT has_function( 'do_something' );
-    SELECT has_function( 'do_something', ARRAY['integer'] );
+    SELECT has_function( 'do_something', ARRAY['int'] );
     SELECT has_function( 'do_something', ARRAY['numeric'] );
-
-The `:args` argument should be formatted as it would be displayed in the view
-of a function using the `\df` command in `psql`. For example, even if you have
-a numeric column with a precision of 8, you should specify `ARRAY['numeric']`.
-If you created a `varchar(64)` column, you should pass the `:args` argument as
-`ARRAY['character varying']`.
 
 If you wish to use the two-argument form of `has_function()`, specifying only
 the schema and the function name, you must cast the `:function` argument to
@@ -5303,9 +5297,9 @@ Feeling Funky
 
 Perhaps more important than testing the database schema is testing your custom
 functions. Especially if you write functions that provide the interface for
-clients to interact with the database, making sure that they work will save
-you time in the long run. So check out these assertions to maintain your
-sanity.
+clients to interact with the database, making sure that they work will save you
+time in the long run. So use these assertions to save yourself heartache in the
+future.
 
 ### `can()` ###
 
@@ -5428,15 +5422,14 @@ But then you check with `has_function()` first, right?
 `:description`
 : A short description of the test.
 
-Tests that a particular function returns a particular data type. The `:args[]`
-and `:type` arguments should be formatted as they would be displayed in the
-view of a function using the `\df` command in `psql`. For example, use
-"character varying" rather than "varchar", and "boolean" rather than "bool".
-For set returning functions, the `:type` argument should start with "setof "
-(yes, lowercase). Examples:
+Tests that a particular function returns a particular data type. The `:type`
+argument should be formatted as it would be displayed in the view of a function
+using the `\df` command in `psql`. For example, use "character varying" rather
+than "varchar", and "boolean" rather than "bool". For set returning functions,
+the `:type` argument should start with "setof " (yes, lowercase). Examples:
 
-    SELECT function_returns( 'myschema', 'foo', ARRAY['integer', 'text'], 'integer' );
-    SELECT function_returns( 'do_something', 'setof bool' );
+    SELECT function_returns( 'myschema', 'foo', ARRAY['int', 'text'], 'integer' );
+    SELECT function_returns( 'do_something', 'setof boolean' );
     SELECT function_returns( 'do_something', ARRAY['integer'], 'boolean' );
     SELECT function_returns( 'do_something', ARRAY['numeric'], 'numeric' );
 

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -4499,8 +4499,8 @@ will fail if the table or column in question does not exist.
 The type argument should be formatted as it would be displayed in the view of
 a table using the `\d` command in `psql`. For example, if you have a numeric
 column with a precision of 8, you should specify "numeric(8,0)". If you
-created a `varchar(64)` column, you should pass the type as "character
-varying(64)". Example:
+created a `varchar(64)` column, you should pass the type as "varchar(64)" or
+"character varying(64)". Example:
 
     SELECT col_type_is( 'myschema', 'sometable', 'somecolumn', 'numeric(10,2)' );
 
@@ -5423,10 +5423,9 @@ But then you check with `has_function()` first, right?
 : A short description of the test.
 
 Tests that a particular function returns a particular data type. The `:type`
-argument should be formatted as it would be displayed in the view of a function
-using the `\df` command in `psql`. For example, use "character varying" rather
-than "varchar", and "boolean" rather than "bool". For set returning functions,
-the `:type` argument should start with "setof " (yes, lowercase). Examples:
+argument may be formatted with full or aliased type names, e.g., `integer`,
+`int4`, or `int`. For set returning functions, the `:type` argument should start
+with "setof " (yes, lowercase). Examples:
 
     SELECT function_returns( 'myschema', 'foo', ARRAY['int', 'text'], 'integer' );
     SELECT function_returns( 'do_something', 'setof boolean' );

--- a/sql/pgtap--1.2.0--1.2.1.sql
+++ b/sql/pgtap--1.2.0--1.2.1.sql
@@ -181,4 +181,131 @@ RETURNS TEXT AS $$
         ),
         $2
     );
+CREATE OR REPLACE FUNCTION _lang ( NAME, NAME, NAME[] )
+RETURNS NAME AS $$
+    SELECT l.lanname
+      FROM tap_funky f
+      JOIN pg_catalog.pg_language l ON f.langoid = l.oid
+     WHERE f.schema = $1
+       and f.name   = $2
+       AND f.args   = _funkargs($3)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _lang ( NAME, NAME[] )
+RETURNS NAME AS $$
+    SELECT l.lanname
+      FROM tap_funky f
+      JOIN pg_catalog.pg_language l ON f.langoid = l.oid
+     WHERE f.name = $1
+       AND f.args = _funkargs($2)
+       AND f.is_visible;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _returns ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT returns
+      FROM tap_funky
+     WHERE schema = $1
+       AND name   = $2
+       AND args   = _funkargs($3)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _returns ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT returns
+      FROM tap_funky
+     WHERE name = $1
+       AND args = _funkargs($2)
+       AND is_visible;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _definer ( NAME, NAME, NAME[] )
+RETURNS BOOLEAN AS $$
+    SELECT is_definer
+      FROM tap_funky
+     WHERE schema = $1
+       AND name   = $2
+       AND args   = _funkargs($3)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _definer ( NAME, NAME[] )
+RETURNS BOOLEAN AS $$
+    SELECT is_definer
+      FROM tap_funky
+     WHERE name = $1
+       AND args = _funkargs($2)
+       AND is_visible;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME, NAME[] )
+RETURNS BOOLEAN AS $$
+    SELECT kind = $1
+      FROM tap_funky
+     WHERE schema = $2
+       AND name   = $3
+       AND args   = _funkargs($4)
+$$ LANGUAGE SQL;
+
+-- _type_func(type, function, args[])
+CREATE OR REPLACE FUNCTION _type_func ( "char", NAME, NAME[] )
+RETURNS BOOLEAN AS $$
+    SELECT kind = $1
+      FROM tap_funky
+     WHERE name = $2
+       AND args = _funkargs($3)
+       AND is_visible;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _strict ( NAME, NAME, NAME[] )
+RETURNS BOOLEAN AS $$
+    SELECT is_strict
+      FROM tap_funky
+     WHERE schema = $1
+       AND name   = $2
+       AND args   = _funkargs($3)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _strict ( NAME, NAME[] )
+RETURNS BOOLEAN AS $$
+    SELECT is_strict
+      FROM tap_funky
+     WHERE name = $1
+       AND args = _funkargs($2)
+       AND is_visible;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _vol ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _expand_vol(volatility)
+      FROM tap_funky f
+     WHERE f.schema = $1
+       and f.name   = $2
+       AND f.args   = _funkargs($3)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _vol ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT _expand_vol(volatility)
+      FROM tap_funky f
+     WHERE f.name = $1
+       AND f.args = _funkargs($2)
+       AND f.is_visible;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _get_func_owner ( NAME, NAME, NAME[] )
+RETURNS NAME AS $$
+    SELECT owner
+      FROM tap_funky
+     WHERE schema = $1
+       AND name   = $2
+       AND args   = _funkargs($3)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _get_func_owner ( NAME, NAME[] )
+RETURNS NAME AS $$
+    SELECT owner
+      FROM tap_funky
+     WHERE name = $1
+       AND args = _funkargs($2)
+       AND is_visible
 $$ LANGUAGE SQL;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1454,26 +1454,24 @@ RETURNS TEXT AS $$
        AND NOT a.attisdropped
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION _typename ( NAME )
+RETURNS TEXT AS $$
+BEGIN RETURN $1::REGTYPE;
+EXCEPTION WHEN undefined_object THEN RETURN $1;
+END;
+$$ LANGUAGE PLPGSQL STABLE;
+
 CREATE OR REPLACE FUNCTION _quote_ident_like(TEXT, TEXT)
 RETURNS TEXT AS $$
 DECLARE
-    have    TEXT;
-    pcision TEXT;
+    typname TEXT := _typename($1);
+    pcision TEXT := COALESCE(substring($1 FROM '[(][^")]+[)]$'), '');
 BEGIN
     -- Just return it if rhs isn't quoted.
-    IF $2 !~ '"' THEN RETURN $1; END IF;
+    IF $2 !~ '"' THEN RETURN typname || pcision; END IF;
 
-    -- If it's quoted ident without precision, return it quoted.
-    IF $2 ~ '"$' THEN RETURN quote_ident($1); END IF;
-
-    pcision := substring($1 FROM '[(][^")]+[)]$');
-
-    -- Just quote it if thre is no precision.
-    if pcision IS NULL THEN RETURN quote_ident($1); END IF;
-
-    -- Quote the non-precision part and concatenate with precision.
-    RETURN quote_ident(substring($1 FOR char_length($1) - char_length(pcision)))
-        || pcision;
+    -- Otherwise return it with the type part quoted.
+    RETURN quote_ident(typname) || pcision;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -4247,6 +4245,7 @@ RETURNS TEXT AS $$
     );
 $$ LANGUAGE SQL;
 
+-- _op_exists( left_type, schema, name, right_type, return_type )
 CREATE OR REPLACE FUNCTION _op_exists ( NAME, NAME, NAME, NAME, NAME )
 RETURNS BOOLEAN AS $$
     SELECT EXISTS (
@@ -4256,13 +4255,14 @@ RETURNS BOOLEAN AS $$
         WHERE n.nspname = $2
           AND o.oprname = $3
           AND CASE o.oprkind WHEN 'l' THEN $1 IS NULL
-              ELSE _cmp_types(o.oprleft, $1) END
+              ELSE _cmp_types(o.oprleft, _typename($1)) END
           AND CASE o.oprkind WHEN 'r' THEN $4 IS NULL
-              ELSE _cmp_types(o.oprright, $4) END
+              ELSE _cmp_types(o.oprright, _typename($4)) END
           AND _cmp_types(o.oprresult, $5)
    );
 $$ LANGUAGE SQL;
 
+-- _op_exists( left_type, name, right_type, return_type )
 CREATE OR REPLACE FUNCTION _op_exists ( NAME, NAME, NAME, NAME )
 RETURNS BOOLEAN AS $$
     SELECT EXISTS (
@@ -4271,13 +4271,14 @@ RETURNS BOOLEAN AS $$
         WHERE pg_catalog.pg_operator_is_visible(o.oid)
           AND o.oprname = $2
           AND CASE o.oprkind WHEN 'l' THEN $1 IS NULL
-              ELSE _cmp_types(o.oprleft, $1) END
+              ELSE _cmp_types(o.oprleft, _typename($1)) END
           AND CASE o.oprkind WHEN 'r' THEN $3 IS NULL
-              ELSE _cmp_types(o.oprright, $3) END
+              ELSE _cmp_types(o.oprright, _typename($3)) END
           AND _cmp_types(o.oprresult, $4)
    );
 $$ LANGUAGE SQL;
 
+-- _op_exists( left_type, name, right_type )
 CREATE OR REPLACE FUNCTION _op_exists ( NAME, NAME, NAME )
 RETURNS BOOLEAN AS $$
     SELECT EXISTS (
@@ -4286,9 +4287,9 @@ RETURNS BOOLEAN AS $$
         WHERE pg_catalog.pg_operator_is_visible(o.oid)
           AND o.oprname = $2
           AND CASE o.oprkind WHEN 'l' THEN $1 IS NULL
-              ELSE _cmp_types(o.oprleft, $1) END
+              ELSE _cmp_types(o.oprleft, _typename($1)) END
           AND CASE o.oprkind WHEN 'r' THEN $3 IS NULL
-              ELSE _cmp_types(o.oprright, $3) END
+              ELSE _cmp_types(o.oprright, _typename($3)) END
    );
 $$ LANGUAGE SQL;
 
@@ -5696,10 +5697,20 @@ RETURNS TEXT AS $$
     SELECT returns FROM tap_funky WHERE name = $1 AND is_visible;
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION _retval(TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    setof TEXT := substring($1 FROM '^setof[[:space:]]+');
+BEGIN
+    IF setof IS NULL THEN RETURN _typename($1); END IF;
+    RETURN setof || _typename(substring($1 FROM char_length(setof)+1));
+END;
+$$ LANGUAGE plpgsql;
+
 -- function_returns( schema, function, args[], type, description )
 CREATE OR REPLACE FUNCTION function_returns( NAME, NAME, NAME[], TEXT, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare($1, $2, $3, _returns($1, $2, $3), $4, $5 );
+    SELECT _func_compare($1, $2, $3, _returns($1, $2, $3), _retval($4), $5 );
 $$ LANGUAGE SQL;
 
 -- function_returns( schema, function, args[], type )
@@ -5715,7 +5726,7 @@ $$ LANGUAGE SQL;
 -- function_returns( schema, function, type, description )
 CREATE OR REPLACE FUNCTION function_returns( NAME, NAME, TEXT, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare($1, $2, _returns($1, $2), $3, $4 );
+    SELECT _func_compare($1, $2, _returns($1, $2), _retval($3), $4 );
 $$ LANGUAGE SQL;
 
 -- function_returns( schema, function, type )
@@ -5731,7 +5742,7 @@ $$ LANGUAGE SQL;
 -- function_returns( function, args[], type, description )
 CREATE OR REPLACE FUNCTION function_returns( NAME, NAME[], TEXT, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare(NULL, $1, $2, _returns($1, $2), $3, $4 );
+    SELECT _func_compare(NULL, $1, $2, _returns($1, $2), _retval($3), $4 );
 $$ LANGUAGE SQL;
 
 -- function_returns( function, args[], type )
@@ -5747,7 +5758,7 @@ $$ LANGUAGE SQL;
 -- function_returns( function, type, description )
 CREATE OR REPLACE FUNCTION function_returns( NAME, TEXT, TEXT )
 RETURNS TEXT AS $$
-    SELECT _func_compare(NULL, $1, _returns($1), $2, $3 );
+    SELECT _func_compare(NULL, $1, _returns($1), _retval($2), $3 );
 $$ LANGUAGE SQL;
 
 -- function_returns( function, type )
@@ -7606,11 +7617,11 @@ RETURNS TEXT AS $$
                AND n.nspname = $1
                AND t.typtype = ANY( COALESCE($4, ARRAY['b', 'c', 'd', 'p', 'e']) )
             EXCEPT
-            SELECT $2[i]
+            SELECT _typename($2[i])
               FROM generate_series(1, array_upper($2, 1)) s(i)
         ),
         ARRAY(
-            SELECT $2[i]
+            SELECT _typename($2[i])
                FROM generate_series(1, array_upper($2, 1)) s(i)
             EXCEPT
             SELECT t.typname
@@ -7658,11 +7669,11 @@ RETURNS TEXT AS $$
                AND pg_catalog.pg_type_is_visible(t.oid)
                AND t.typtype = ANY( COALESCE($3, ARRAY['b', 'c', 'd', 'p', 'e']) )
             EXCEPT
-            SELECT $1[i]
+            SELECT _typename($1[i])
               FROM generate_series(1, array_upper($1, 1)) s(i)
         ),
         ARRAY(
-            SELECT $1[i]
+            SELECT _typename($1[i])
                FROM generate_series(1, array_upper($1, 1)) s(i)
             EXCEPT
             SELECT t.typname
@@ -7680,7 +7691,6 @@ RETURNS TEXT AS $$
         $2
     );
 $$ LANGUAGE SQL;
-
 
 -- types_are( types[], description )
 CREATE OR REPLACE FUNCTION types_are ( NAME[], TEXT )
@@ -8075,7 +8085,6 @@ BEGIN
     RETURN ok(res, descr) || msg;
 END;
 $$ LANGUAGE plpgsql;
-
 
 -- casts_are( casts[], description )
 CREATE OR REPLACE FUNCTION casts_are ( TEXT[], TEXT )

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -5573,7 +5573,7 @@ RETURNS NAME AS $$
       JOIN pg_catalog.pg_language l ON f.langoid = l.oid
      WHERE f.schema = $1
        and f.name   = $2
-       AND f.args   = array_to_string($3, ',')
+       AND f.args   = _funkargs($3)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _lang ( NAME, NAME )
@@ -5591,7 +5591,7 @@ RETURNS NAME AS $$
       FROM tap_funky f
       JOIN pg_catalog.pg_language l ON f.langoid = l.oid
      WHERE f.name = $1
-       AND f.args = array_to_string($2, ',')
+       AND f.args = _funkargs($2)
        AND f.is_visible;
 $$ LANGUAGE SQL;
 
@@ -5674,7 +5674,7 @@ RETURNS TEXT AS $$
       FROM tap_funky
      WHERE schema = $1
        AND name   = $2
-       AND args   = array_to_string($3, ',')
+       AND args   = _funkargs($3)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _returns ( NAME, NAME )
@@ -5687,7 +5687,7 @@ RETURNS TEXT AS $$
     SELECT returns
       FROM tap_funky
      WHERE name = $1
-       AND args = array_to_string($2, ',')
+       AND args = _funkargs($2)
        AND is_visible;
 $$ LANGUAGE SQL;
 
@@ -5765,7 +5765,7 @@ RETURNS BOOLEAN AS $$
       FROM tap_funky
      WHERE schema = $1
        AND name   = $2
-       AND args   = array_to_string($3, ',')
+       AND args   = _funkargs($3)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _definer ( NAME, NAME )
@@ -5778,7 +5778,7 @@ RETURNS BOOLEAN AS $$
     SELECT is_definer
       FROM tap_funky
      WHERE name = $1
-       AND args = array_to_string($2, ',')
+       AND args = _funkargs($2)
        AND is_visible;
 $$ LANGUAGE SQL;
 
@@ -5916,7 +5916,7 @@ RETURNS BOOLEAN AS $$
       FROM tap_funky
      WHERE schema = $2
        AND name   = $3
-       AND args   = array_to_string($4, ',')
+       AND args   = _funkargs($4)
 $$ LANGUAGE SQL;
 
 -- _type_func(type, schema, function)
@@ -5931,7 +5931,7 @@ RETURNS BOOLEAN AS $$
     SELECT kind = $1
       FROM tap_funky
      WHERE name = $2
-       AND args = array_to_string($3, ',')
+       AND args = _funkargs($3)
        AND is_visible;
 $$ LANGUAGE SQL;
 
@@ -6071,7 +6071,7 @@ RETURNS BOOLEAN AS $$
       FROM tap_funky
      WHERE schema = $1
        AND name   = $2
-       AND args   = array_to_string($3, ',')
+       AND args   = _funkargs($3)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _strict ( NAME, NAME )
@@ -6084,7 +6084,7 @@ RETURNS BOOLEAN AS $$
     SELECT is_strict
       FROM tap_funky
      WHERE name = $1
-       AND args = array_to_string($2, ',')
+       AND args = _funkargs($2)
        AND is_visible;
 $$ LANGUAGE SQL;
 
@@ -6231,7 +6231,7 @@ RETURNS TEXT AS $$
       FROM tap_funky f
      WHERE f.schema = $1
        and f.name   = $2
-       AND f.args   = array_to_string($3, ',')
+       AND f.args   = _funkargs($3)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _vol ( NAME, NAME )
@@ -6245,7 +6245,7 @@ RETURNS TEXT AS $$
     SELECT _expand_vol(volatility)
       FROM tap_funky f
      WHERE f.name = $1
-       AND f.args = array_to_string($2, ',')
+       AND f.args = _funkargs($2)
        AND f.is_visible;
 $$ LANGUAGE SQL;
 
@@ -8697,7 +8697,7 @@ RETURNS NAME AS $$
       FROM tap_funky
      WHERE schema = $1
        AND name   = $2
-       AND args   = array_to_string($3, ',')
+       AND args   = _funkargs($3)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _get_func_owner ( NAME, NAME[] )
@@ -8705,7 +8705,7 @@ RETURNS NAME AS $$
     SELECT owner
       FROM tap_funky
      WHERE name = $1
-       AND args = array_to_string($2, ',')
+       AND args = _funkargs($2)
        AND is_visible
 $$ LANGUAGE SQL;
 

--- a/test/sql/aretap.sql
+++ b/test/sql/aretap.sql
@@ -82,7 +82,6 @@ CREATE TYPE someschema."myType" AS (
     foo INT
 );
 
-
 RESET client_min_messages;
 
 /****************************************************************************/

--- a/test/sql/coltap.sql
+++ b/test/sql/coltap.sql
@@ -167,18 +167,18 @@ SELECT * FROM check_test(
 /****************************************************************************/
 -- Test col_type_is().
 SELECT * FROM check_test(
-    col_type_is( 'public', 'sometab', 'name', 'pg_catalog', 'text', 'name is text' ),
+    col_type_is( 'public', 'sometab', 'ctstz', 'pg_catalog', 'timestamptz', 'ctstz is tstz' ),
     true,
     'col_type_is( sch, tab, col, sch, type, desc )',
-    'name is text',
+    'ctstz is tstz',
     ''
 );
 
 SELECT * FROM check_test(
-    col_type_is( 'public', 'sometab', 'name', 'pg_catalog'::name, 'text' ),
+    col_type_is( 'public', 'sometab', 'ctstz', 'pg_catalog'::name, 'timestamptz' ),
     true,
     'col_type_is( sch, tab, col, sch, type, desc )',
-    'Column public.sometab.name should be type pg_catalog.text',
+    'Column public.sometab.ctstz should be type pg_catalog.timestamptz',
     ''
 );
 
@@ -226,7 +226,7 @@ SELECT * FROM check_test(
 
 -- Try failures.
 SELECT * FROM check_test(
-    col_type_is( 'public', 'sometab', 'name', 'pg_catalog', 'integer', 'whatever' ),
+    col_type_is( 'public', 'sometab', 'name', 'pg_catalog', 'int', 'whatever' ),
     false,
     'col_type_is( sch, tab, col, sch, type, desc ) fail',
     'whatever',
@@ -299,7 +299,7 @@ SELECT * FROM check_test(
     'col_type_is( tab, col, type ) fail',
     'Column sometab.name should be type int4',
     '        have: text
-        want: int4'
+        want: integer'
 );
 
 -- Make sure missing column is in diagnostics.

--- a/test/sql/functap.sql
+++ b/test/sql/functap.sql
@@ -559,7 +559,7 @@ SELECT * FROM check_test(
 /****************************************************************************/
 -- Test function_returns().
 SELECT * FROM check_test(
-    function_returns( 'someschema', 'huh', '{}'::name[], 'boolean', 'whatever' ),
+    function_returns( 'someschema', 'huh', '{}'::name[], 'bool', 'whatever' ),
     true,
     'function_returns(schema, func, 0 args, bool, desc)',
     'whatever',
@@ -575,7 +575,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'someschema', 'bah', ARRAY['int', 'text'], 'boolean', 'whatever' ),
+    function_returns( 'someschema', 'bah', ARRAY['int', 'text'], 'bool', 'whatever' ),
     true,
     'function_returns(schema, func, args, bool, false)',
     'whatever',
@@ -591,7 +591,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'public', 'pet', '{}'::name[], 'setof boolean', 'whatever' ),
+    function_returns( 'public', 'pet', '{}'::name[], 'setof bool', 'whatever' ),
     true,
     'function_returns(schema, func, 0 args, setof bool, desc)',
     'whatever',
@@ -607,7 +607,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'someschema', 'huh', 'boolean', 'whatever' ),
+    function_returns( 'someschema', 'huh', 'bool', 'whatever' ),
     true,
     'function_returns(schema, func, bool, desc)',
     'whatever',
@@ -623,7 +623,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'someschema', 'bah', 'boolean', 'whatever' ),
+    function_returns( 'someschema', 'bah', 'bool', 'whatever' ),
     true,
     'function_returns(schema, other func, bool, false)',
     'whatever',
@@ -639,7 +639,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'public', 'pet', 'setof boolean', 'whatever' ),
+    function_returns( 'public', 'pet', 'setof bool', 'whatever' ),
     true,
     'function_returns(schema, func, setof bool, desc)',
     'whatever',
@@ -655,7 +655,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'yay', '{}'::name[], 'boolean', 'whatever' ),
+    function_returns( 'yay', '{}'::name[], 'bool', 'whatever' ),
     true,
     'function_returns(func, 0 args, bool, desc)',
     'whatever',
@@ -671,7 +671,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'oww', ARRAY['int', 'text'], 'boolean', 'whatever' ),
+    function_returns( 'oww', ARRAY['int', 'text'], 'bool', 'whatever' ),
     true,
     'function_returns(func, args, bool, false)',
     'whatever',
@@ -687,7 +687,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'pet', '{}'::name[], 'setof boolean', 'whatever' ),
+    function_returns( 'pet', '{}'::name[], 'setof bool', 'whatever' ),
     true,
     'function_returns(func, 0 args, setof bool, desc)',
     'whatever',
@@ -703,7 +703,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'yay', 'boolean', 'whatever' ),
+    function_returns( 'yay', 'bool', 'whatever' ),
     true,
     'function_returns(func, bool, desc)',
     'whatever',
@@ -719,7 +719,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'oww', 'boolean', 'whatever' ),
+    function_returns( 'oww', 'bool', 'whatever' ),
     true,
     'function_returns(other func, bool, false)',
     'whatever',
@@ -735,7 +735,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'pet', 'setof boolean', 'whatever' ),
+    function_returns( 'pet', 'setof bool', 'whatever' ),
     true,
     'function_returns(func, setof bool, desc)',
     'whatever',

--- a/test/sql/functap.sql
+++ b/test/sql/functap.sql
@@ -114,18 +114,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    has_function( 'lower', '{text}'::name[] ),
+    has_function( 'abs', '{int}'::name[] ),
     true,
     'simple function with 1 arg',
-    'Function lower(text) should exist',
+    'Function abs(int) should exist',
     ''
 );
 
 SELECT * FROM check_test(
-    has_function( 'decode', '{text,text}'::name[] ),
+    has_function( 'age', '{timestamptz,timestamptz}'::name[] ),
     true,
     'simple function with 2 args',
-    'Function decode(text, text) should exist',
+    'Function age(timestamptz, timestamptz) should exist',
     ''
 );
 
@@ -393,7 +393,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_lang_is( 'someschema', 'bah', '{"integer", "text"}'::name[], 'plpgsql', 'whatever' ),
+    function_lang_is( 'someschema', 'bah', '{"int", "text"}'::name[], 'plpgsql', 'whatever' ),
     true,
     'function_lang_is(schema, func, args, plpgsql, desc)',
     'whatever',
@@ -401,10 +401,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_lang_is( 'someschema', 'bah', '{"integer", "text"}'::name[], 'plpgsql' ),
+    function_lang_is( 'someschema', 'bah', '{"int", "text"}'::name[], 'plpgsql' ),
     true,
     'function_lang_is(schema, func, args, plpgsql)',
-    'Function someschema.bah(integer, text) should be written in plpgsql',
+    'Function someschema.bah(int, text) should be written in plpgsql',
     ''
 );
 
@@ -426,11 +426,11 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_lang_is( 'someschema', 'why', '{"integer", "text"}'::name[], 'plpgsql' ),
+    function_lang_is( 'someschema', 'why', '{"int", "text"}'::name[], 'plpgsql' ),
     false,
     'function_lang_is(schema, func, args, plpgsql)',
-    'Function someschema.why(integer, text) should be written in plpgsql',
-    '    Function someschema.why(integer, text) does not exist'
+    'Function someschema.why(int, text) should be written in plpgsql',
+    '    Function someschema.why(int, text) does not exist'
 );
 
 SELECT * FROM check_test(
@@ -483,7 +483,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_lang_is( 'oww', '{"integer", "text"}'::name[], 'plpgsql', 'whatever' ),
+    function_lang_is( 'oww', '{"int", "text"}'::name[], 'plpgsql', 'whatever' ),
     true,
     'function_lang_is(func, args, plpgsql, desc)',
     'whatever',
@@ -491,10 +491,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_lang_is( 'oww', '{"integer", "text"}'::name[], 'plpgsql' ),
+    function_lang_is( 'oww', '{"int", "text"}'::name[], 'plpgsql' ),
     true,
     'function_lang_is(func, args, plpgsql)',
-    'Function oww(integer, text) should be written in plpgsql',
+    'Function oww(int, text) should be written in plpgsql',
     ''
 );
 
@@ -516,11 +516,11 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_lang_is( 'why', '{"integer", "text"}'::name[], 'plpgsql' ),
+    function_lang_is( 'why', '{"int", "text"}'::name[], 'plpgsql' ),
     false,
     'function_lang_is(func, args, plpgsql)',
-    'Function why(integer, text) should be written in plpgsql',
-    '    Function why(integer, text) does not exist'
+    'Function why(int, text) should be written in plpgsql',
+    '    Function why(int, text) does not exist'
 );
 
 SELECT * FROM check_test(
@@ -575,7 +575,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'someschema', 'bah', ARRAY['integer', 'text'], 'boolean', 'whatever' ),
+    function_returns( 'someschema', 'bah', ARRAY['int', 'text'], 'boolean', 'whatever' ),
     true,
     'function_returns(schema, func, args, bool, false)',
     'whatever',
@@ -583,10 +583,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'someschema', 'bah', ARRAY['integer', 'text'], 'boolean' ),
+    function_returns( 'someschema', 'bah', ARRAY['int', 'text'], 'boolean' ),
     true,
     'function_returns(schema, func, args, bool)',
-    'Function someschema.bah(integer, text) should return boolean',
+    'Function someschema.bah(int, text) should return boolean',
     ''
 );
 
@@ -671,7 +671,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'oww', ARRAY['integer', 'text'], 'boolean', 'whatever' ),
+    function_returns( 'oww', ARRAY['int', 'text'], 'boolean', 'whatever' ),
     true,
     'function_returns(func, args, bool, false)',
     'whatever',
@@ -679,10 +679,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    function_returns( 'oww', ARRAY['integer', 'text'], 'boolean' ),
+    function_returns( 'oww', ARRAY['int', 'text'], 'boolean' ),
     true,
     'function_returns(func, args, bool)',
-    'Function oww(integer, text) should return boolean',
+    'Function oww(int, text) should return boolean',
     ''
 );
 
@@ -785,7 +785,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_definer( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_definer( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_definer(schema, func, args, desc)',
     'whatever',
@@ -793,7 +793,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_definer( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_definer( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_definer(schema, func, args, desc)',
     'whatever',
@@ -801,18 +801,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_definer( 'public', 'oww', ARRAY['integer', 'text'] ),
+    is_definer( 'public', 'oww', ARRAY['int', 'text'] ),
     false,
     'is_definer(schema, func, args)',
-    'Function public.oww(integer, text) should be security definer',
+    'Function public.oww(int, text) should be security definer',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_definer( 'public', 'oww', ARRAY['integer', 'text'] ),
+    isnt_definer( 'public', 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_definer(schema, func, args)',
-    'Function public.oww(integer, text) should not be security definer',
+    'Function public.oww(int, text) should not be security definer',
     ''
 );
 
@@ -881,7 +881,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_definer( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_definer( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_definer(schema, func, args, desc)',
     'whatever',
@@ -889,7 +889,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_definer( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_definer( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_definer(schema, func, args, desc)',
     'whatever',
@@ -897,18 +897,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_definer( 'public', 'oww', ARRAY['integer', 'text'] ),
+    is_definer( 'public', 'oww', ARRAY['int', 'text'] ),
     false,
     'is_definer(schema, func, args)',
-    'Function public.oww(integer, text) should be security definer',
+    'Function public.oww(int, text) should be security definer',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_definer( 'public', 'oww', ARRAY['integer', 'text'] ),
+    isnt_definer( 'public', 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_definer(schema, func, args)',
-    'Function public.oww(integer, text) should not be security definer',
+    'Function public.oww(int, text) should not be security definer',
     ''
 );
 
@@ -977,7 +977,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_definer( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_definer( 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_definer(func, args, desc)',
     'whatever',
@@ -985,7 +985,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_definer( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_definer( 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_definer(func, args, desc)',
     'whatever',
@@ -993,18 +993,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_definer( 'oww', ARRAY['integer', 'text'] ),
+    is_definer( 'oww', ARRAY['int', 'text'] ),
     false,
     'is_definer(func, args)',
-    'Function oww(integer, text) should be security definer',
+    'Function oww(int, text) should be security definer',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_definer( 'oww', ARRAY['integer', 'text'] ),
+    isnt_definer( 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_definer(func, args)',
-    'Function oww(integer, text) should not be security definer',
+    'Function oww(int, text) should not be security definer',
     ''
 );
 
@@ -1078,7 +1078,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_normal_function( 'someschema', 'bah', ARRAY['integer', 'text'], 'whatever' ),
+    is_normal_function( 'someschema', 'bah', ARRAY['int', 'text'], 'whatever' ),
     true,
     'is_normal_function(schema, func, args, desc)',
     'whatever',
@@ -1094,7 +1094,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_normal_function( 'someschema', 'bah', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_normal_function( 'someschema', 'bah', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_normal_function(schema, func, args, desc)',
     'whatever',
@@ -1161,18 +1161,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_normal_function( 'someschema', 'bah', ARRAY['integer', 'text'] ),
+    is_normal_function( 'someschema', 'bah', ARRAY['int', 'text'] ),
     true,
     'is_normal_function(schema, func2, args)',
-    'Function someschema.bah(integer, text) should be a normal function',
+    'Function someschema.bah(int, text) should be a normal function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_normal_function( 'someschema', 'bah', ARRAY['integer', 'text'] ),
+    isnt_normal_function( 'someschema', 'bah', ARRAY['int', 'text'] ),
     false,
     'isnt_normal_function(schema, func2, args)',
-    'Function someschema.bah(integer, text) should not be a normal function',
+    'Function someschema.bah(int, text) should not be a normal function',
     ''
 );
 
@@ -1363,7 +1363,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_normal_function( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_normal_function( 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'is_normal_function(func, args, desc)',
     'whatever',
@@ -1371,7 +1371,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_normal_function( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_normal_function( 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'isnt_normal_function(func, args, desc)',
     'whatever',
@@ -1414,18 +1414,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_normal_function( 'oww', ARRAY['integer', 'text'] ),
+    is_normal_function( 'oww', ARRAY['int', 'text'] ),
     true,
     'is_normal_function(func, noargs)',
-    'Function oww(integer, text) should be a normal function',
+    'Function oww(int, text) should be a normal function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_normal_function( 'oww', ARRAY['integer', 'text'] ),
+    isnt_normal_function( 'oww', ARRAY['int', 'text'] ),
     false,
     'isnt_normal_function(func, noargs)',
-    'Function oww(integer, text) should not be a normal function',
+    'Function oww(int, text) should not be a normal function',
     ''
 );
 
@@ -1602,7 +1602,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_aggregate( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_aggregate( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_aggregate(schema, func, args, desc)',
     'whatever',
@@ -1610,7 +1610,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_aggregate( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_aggregate( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_aggregate(schema, func, args, desc)',
     'whatever',
@@ -1653,18 +1653,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_aggregate( 'public', 'oww', ARRAY['integer', 'text'] ),
+    is_aggregate( 'public', 'oww', ARRAY['int', 'text'] ),
     false,
     'is_aggregate(schema, func, args)',
-    'Function public.oww(integer, text) should be an aggregate function',
+    'Function public.oww(int, text) should be an aggregate function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_aggregate( 'public', 'oww', ARRAY['integer', 'text'] ),
+    isnt_aggregate( 'public', 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_aggregate(schema, func, args)',
-    'Function public.oww(integer, text) should not be an aggregate function',
+    'Function public.oww(int, text) should not be an aggregate function',
     ''
 );
 
@@ -1774,7 +1774,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_aggregate( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_aggregate( 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_aggregate(func, args, desc)',
     'whatever',
@@ -1782,7 +1782,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_aggregate( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_aggregate( 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_aggregate(func, args, desc)',
     'whatever',
@@ -1825,18 +1825,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_aggregate( 'oww', ARRAY['integer', 'text'] ),
+    is_aggregate( 'oww', ARRAY['int', 'text'] ),
     false,
     'is_aggregate(func, args)',
-    'Function oww(integer, text) should be an aggregate function',
+    'Function oww(int, text) should be an aggregate function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_aggregate( 'oww', ARRAY['integer', 'text'] ),
+    isnt_aggregate( 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_aggregate(func, args)',
-    'Function oww(integer, text) should not be an aggregate function',
+    'Function oww(int, text) should not be an aggregate function',
     ''
 );
 
@@ -1933,7 +1933,7 @@ SELECT * FROM check_test(
 -- is_window ( NAME, NAME, NAME[], TEXT )
 -- isnt_window ( NAME, NAME, NAME[], TEXT )
 SELECT * FROM check_test(
-    is_window( 'pg_catalog', 'ntile', ARRAY['integer'], 'whatever' ),
+    is_window( 'pg_catalog', 'ntile', ARRAY['int'], 'whatever' ),
     true,
     'is_window(schema, win, arg, desc)',
     'whatever',
@@ -1941,7 +1941,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'pg_catalog', 'ntile', ARRAY['integer'], 'whatever' ),
+    isnt_window( 'pg_catalog', 'ntile', ARRAY['int'], 'whatever' ),
     false,
     'isnt_window(schema, win, arg, desc)',
     'whatever',
@@ -1949,7 +1949,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_window( 'someschema', 'bah', ARRAY['integer', 'text'], 'whatever' ),
+    is_window( 'someschema', 'bah', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_window(schema, func, arg, desc)',
     'whatever',
@@ -1957,7 +1957,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'someschema', 'bah', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_window( 'someschema', 'bah', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_window(schema, func, arg, desc)',
     'whatever',
@@ -1998,52 +1998,52 @@ SELECT * FROM check_test(
 
 -- Test diagnostics
 SELECT * FROM check_test(
-    is_window( 'someschema', 'nope', ARRAY['integer'], 'whatever' ),
+    is_window( 'someschema', 'nope', ARRAY['int'], 'whatever' ),
     false,
     'is_window(schema, nowin, arg, desc)',
     'whatever',
-    '    Function someschema.nope(integer) does not exist'
+    '    Function someschema.nope(int) does not exist'
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'someschema', 'nope', ARRAY['integer'], 'whatever' ),
+    isnt_window( 'someschema', 'nope', ARRAY['int'], 'whatever' ),
     false,
     'isnt_window(schema, nowin, arg, desc)',
     'whatever',
-    '    Function someschema.nope(integer) does not exist'
+    '    Function someschema.nope(int) does not exist'
 );
 
 -- is_window ( NAME, NAME, NAME[] )
 -- isnt_window ( NAME, NAME, NAME[] )
 SELECT * FROM check_test(
-    is_window( 'pg_catalog', 'ntile', ARRAY['integer'] ),
+    is_window( 'pg_catalog', 'ntile', ARRAY['int'] ),
     true,
     'is_window(schema, win, arg)',
-    'Function pg_catalog.ntile(integer) should be a window function',
+    'Function pg_catalog.ntile(int) should be a window function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'pg_catalog', 'ntile', ARRAY['integer'] ),
+    isnt_window( 'pg_catalog', 'ntile', ARRAY['int'] ),
     false,
     'isnt_window(schema, win, arg)',
-    'Function pg_catalog.ntile(integer) should not be a window function',
+    'Function pg_catalog.ntile(int) should not be a window function',
     ''
 );
 
 SELECT * FROM check_test(
-    is_window( 'someschema', 'bah', ARRAY['integer', 'text'] ),
+    is_window( 'someschema', 'bah', ARRAY['int', 'text'] ),
     false,
     'is_window(schema, func, arg)',
-    'Function someschema.bah(integer, text) should be a window function',
+    'Function someschema.bah(int, text) should be a window function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'someschema', 'bah', ARRAY['integer', 'text'] ),
+    isnt_window( 'someschema', 'bah', ARRAY['int', 'text'] ),
     true,
     'isnt_window(schema, func, arg)',
-    'Function someschema.bah(integer, text) should not be a window function',
+    'Function someschema.bah(int, text) should not be a window function',
     ''
 );
 
@@ -2081,19 +2081,19 @@ SELECT * FROM check_test(
 
 -- Test diagnostics
 SELECT * FROM check_test(
-    is_window( 'someschema', 'nada', ARRAY['integer'] ),
+    is_window( 'someschema', 'nada', ARRAY['int'] ),
     false,
     'is_window(schema, nowin, arg)',
-    'Function someschema.nada(integer) should be a window function',
-    '    Function someschema.nada(integer) does not exist'
+    'Function someschema.nada(int) should be a window function',
+    '    Function someschema.nada(int) does not exist'
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'someschema', 'nada', ARRAY['integer'] ),
+    isnt_window( 'someschema', 'nada', ARRAY['int'] ),
     false,
     'isnt_window(schema, nowin, arg)',
-    'Function someschema.nada(integer) should not be a window function',
-    '    Function someschema.nada(integer) does not exist'
+    'Function someschema.nada(int) should not be a window function',
+    '    Function someschema.nada(int) does not exist'
 );
 
 -- is_window ( NAME, NAME, TEXT )
@@ -2217,7 +2217,7 @@ SELECT * FROM check_test(
 -- is_window ( NAME, NAME[], TEXT )
 -- isnt_window ( NAME, NAME[], TEXT )
 SELECT * FROM check_test(
-    is_window( 'ntile', ARRAY['integer'], 'whatever' ),
+    is_window( 'ntile', ARRAY['int'], 'whatever' ),
     true,
     'is_window(win, arg, desc)',
     'whatever',
@@ -2225,7 +2225,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'ntile', ARRAY['integer'], 'whatever' ),
+    isnt_window( 'ntile', ARRAY['int'], 'whatever' ),
     false,
     'isnt_window(win, arg, desc)',
     'whatever',
@@ -2233,7 +2233,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_window( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_window( 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_window(func, arg, desc)',
     'whatever',
@@ -2241,7 +2241,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_window( 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_window(func, arg, desc)',
     'whatever',
@@ -2282,52 +2282,52 @@ SELECT * FROM check_test(
 
 -- Test diagnostics
 SELECT * FROM check_test(
-    is_window( 'nada', ARRAY['integer'], 'whatever' ),
+    is_window( 'nada', ARRAY['int'], 'whatever' ),
     false,
     'is_window(nowin, arg, desc)',
     'whatever',
-    '    Function nada(integer) does not exist'
+    '    Function nada(int) does not exist'
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'nada', ARRAY['integer'], 'whatever' ),
+    isnt_window( 'nada', ARRAY['int'], 'whatever' ),
     false,
     'isnt_window(nowin, arg, desc)',
     'whatever',
-    '    Function nada(integer) does not exist'
+    '    Function nada(int) does not exist'
 );
 
 -- is_window( NAME, NAME[] )
 -- isnt_window( NAME, NAME[] )
 SELECT * FROM check_test(
-    is_window( 'ntile', ARRAY['integer'] ),
+    is_window( 'ntile', ARRAY['int'] ),
     true,
     'is_window(win, arg, desc)',
-    'Function ntile(integer) should be a window function',
+    'Function ntile(int) should be a window function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'ntile', ARRAY['integer'] ),
+    isnt_window( 'ntile', ARRAY['int'] ),
     false,
     'isnt_window(win, arg, desc)',
-    'Function ntile(integer) should not be a window function',
+    'Function ntile(int) should not be a window function',
     ''
 );
 
 SELECT * FROM check_test(
-    is_window( 'oww', ARRAY['integer', 'text'] ),
+    is_window( 'oww', ARRAY['int', 'text'] ),
     false,
     'is_window(func, arg, desc)',
-    'Function oww(integer, text) should be a window function',
+    'Function oww(int, text) should be a window function',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'oww', ARRAY['integer', 'text'] ),
+    isnt_window( 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_window(func, arg, desc)',
-    'Function oww(integer, text) should not be a window function',
+    'Function oww(int, text) should not be a window function',
     ''
 );
 
@@ -2365,19 +2365,19 @@ SELECT * FROM check_test(
 
 -- Test diagnostics
 SELECT * FROM check_test(
-    is_window( 'nope', ARRAY['integer'] ),
+    is_window( 'nope', ARRAY['int'] ),
     false,
     'is_window(nowin, arg, desc)',
-    'Function nope(integer) should be a window function',
-    '    Function nope(integer) does not exist'
+    'Function nope(int) should be a window function',
+    '    Function nope(int) does not exist'
 );
 
 SELECT * FROM check_test(
-    isnt_window( 'nope', ARRAY['integer'] ),
+    isnt_window( 'nope', ARRAY['int'] ),
     false,
     'isnt_window(nowin, arg, desc)',
-    'Function nope(integer) should not be a window function',
-    '    Function nope(integer) does not exist'
+    'Function nope(int) should not be a window function',
+    '    Function nope(int) does not exist'
 );
 
 -- is_window( NAME, TEXT )
@@ -2525,7 +2525,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_strict( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_strict( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_strict(schema, func, args, desc)',
     'whatever',
@@ -2533,7 +2533,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_strict( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_strict( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_strict(schema, func, args, desc)',
     'whatever',
@@ -2541,18 +2541,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_strict( 'public', 'oww', ARRAY['integer', 'text'] ),
+    is_strict( 'public', 'oww', ARRAY['int', 'text'] ),
     false,
     'is_strict(schema, func, args)',
-    'Function public.oww(integer, text) should be strict',
+    'Function public.oww(int, text) should be strict',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_strict( 'public', 'oww', ARRAY['integer', 'text'] ),
+    isnt_strict( 'public', 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_strict(schema, func, args)',
-    'Function public.oww(integer, text) should not be strict',
+    'Function public.oww(int, text) should not be strict',
     ''
 );
 
@@ -2589,7 +2589,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_strict( 'public', 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_strict( 'public', 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_strict(schema, func, args, desc)',
     'whatever',
@@ -2597,10 +2597,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_strict( 'public', 'oww', ARRAY['integer', 'text'] ),
+    isnt_strict( 'public', 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_strict(schema, func, args)',
-    'Function public.oww(integer, text) should not be strict',
+    'Function public.oww(int, text) should not be strict',
     ''
 );
 
@@ -2637,7 +2637,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_strict( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    is_strict( 'oww', ARRAY['int', 'text'], 'whatever' ),
     false,
     'is_strict(func, args, desc)',
     'whatever',
@@ -2645,7 +2645,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    isnt_strict( 'oww', ARRAY['integer', 'text'], 'whatever' ),
+    isnt_strict( 'oww', ARRAY['int', 'text'], 'whatever' ),
     true,
     'isnt_strict(func, args, desc)',
     'whatever',
@@ -2653,18 +2653,18 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    is_strict( 'oww', ARRAY['integer', 'text'] ),
+    is_strict( 'oww', ARRAY['int', 'text'] ),
     false,
     'is_strict(func, args)',
-    'Function oww(integer, text) should be strict',
+    'Function oww(int, text) should be strict',
     ''
 );
 
 SELECT * FROM check_test(
-    isnt_strict( 'oww', ARRAY['integer', 'text'] ),
+    isnt_strict( 'oww', ARRAY['int', 'text'] ),
     true,
     'isnt_strict(func, args)',
-    'Function oww(integer, text) should not be strict',
+    'Function oww(int, text) should not be strict',
     ''
 );
 
@@ -2719,7 +2719,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    volatility_is( 'public', 'oww', ARRAY['integer', 'text'], 'immutable', 'whatever' ),
+    volatility_is( 'public', 'oww', ARRAY['int', 'text'], 'immutable', 'whatever' ),
     true,
     'function_volatility(schema, func, args, immutable, desc)',
     'whatever',
@@ -2743,10 +2743,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    volatility_is( 'public', 'oww', ARRAY['integer', 'text'], 'immutable' ),
+    volatility_is( 'public', 'oww', ARRAY['int', 'text'], 'immutable' ),
     true,
     'function_volatility(schema, func, args, immutable)',
-    'Function public.oww(integer, text) should be IMMUTABLE'
+    'Function public.oww(int, text) should be IMMUTABLE'
     ''
 );
 
@@ -2799,7 +2799,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    volatility_is( 'oww', ARRAY['integer', 'text'], 'immutable', 'whatever' ),
+    volatility_is( 'oww', ARRAY['int', 'text'], 'immutable', 'whatever' ),
     true,
     'function_volatility(func, args, immutable, desc)',
     'whatever',
@@ -2823,10 +2823,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    volatility_is( 'oww', ARRAY['integer', 'text'], 'immutable' ),
+    volatility_is( 'oww', ARRAY['int', 'text'], 'immutable' ),
     true,
     'function_volatility(func, args, immutable)',
-    'Function oww(integer, text) should be IMMUTABLE'
+    'Function oww(int, text) should be IMMUTABLE'
     ''
 );
 

--- a/test/sql/hastap.sql
+++ b/test/sql/hastap.sql
@@ -1360,7 +1360,7 @@ SELECT * FROM check_test(
 -- Test has_operator().
 
 SELECT * FROM check_test(
-  has_operator( 'integer', 'pg_catalog', '<=', 'integer', 'boolean', 'desc' ),
+  has_operator( 'integer', 'pg_catalog', '<=', 'int', 'bool', 'desc' ),
   true,
   'has_operator( left, schema, name, right, result, desc )',
   'desc',
@@ -1376,7 +1376,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', '<=', 'integer', 'boolean', 'desc' ),
+  has_operator( 'integer', '<=', 'int', 'bool', 'desc' ),
   true,
   'has_operator( left, name, right, result, desc )',
   'desc',
@@ -1392,7 +1392,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', '<=', 'integer', 'desc' ),
+  has_operator( 'integer', '<=', 'int', 'desc' ),
   true,
   'has_operator( left, name, right, desc )',
   'desc',
@@ -1408,7 +1408,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', 'pg_catalog', '<=', 'text', 'boolean', 'desc' ),
+  has_operator( 'integer', 'pg_catalog', '<=', 'text', 'bool', 'desc' ),
   false,
   'has_operator( left, schema, name, right, result, desc ) fail',
   'desc',
@@ -1424,7 +1424,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', '<=', 'text', 'boolean', 'desc' ),
+  has_operator( 'integer', '<=', 'text', 'bool', 'desc' ),
   false,
   'has_operator( left, name, right, result, desc ) fail',
   'desc',
@@ -1467,10 +1467,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_operator( 'integer', 'pg_catalog', '<=', 'integer', 'boolean'::name ),
+  hasnt_operator( 'integer', 'pg_catalog', '<=', 'int', 'bool'::name ),
   false,
   'hasnt_operator( left, schema, name, right, result ) fail',
-  'Operator pg_catalog.<=(integer,integer) RETURNS boolean should not exist',
+  'Operator pg_catalog.<=(integer,int) RETURNS bool should not exist',
   ''
 );
 
@@ -1483,10 +1483,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_operator( 'integer', '<=', 'integer', 'boolean'::name ),
+  hasnt_operator( 'integer', '<=', 'int', 'bool'::name ),
   false,
   'hasnt_operator( left, name, right, result ) fail',
-  'Operator <=(integer,integer) RETURNS boolean should not exist',
+  'Operator <=(integer,int) RETURNS bool should not exist',
   ''
 );
 
@@ -1499,10 +1499,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_operator( 'integer', '<=', 'integer'::name ),
+  hasnt_operator( 'integer', '<=', 'int'::name ),
   false,
   'hasnt_operator( left, name, right ) fail',
-  'Operator <=(integer,integer) should not exist',
+  'Operator <=(integer,int) should not exist',
   ''
 );
 
@@ -1515,10 +1515,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_operator( 'integer', 'pg_catalog', '<=', 'text', 'boolean'::name ),
+  hasnt_operator( 'integer', 'pg_catalog', '<=', 'text', 'bool'::name ),
   true,
   'hasnt_operator( left, schema, name, right, result )',
-  'Operator pg_catalog.<=(integer,text) RETURNS boolean should not exist',
+  'Operator pg_catalog.<=(integer,text) RETURNS bool should not exist',
   ''
 );
 
@@ -1531,10 +1531,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_operator( 'integer', '<=', 'text', 'boolean'::name ),
+  hasnt_operator( 'integer', '<=', 'text', 'bool'::name ),
   true,
   'hasnt_operator( left, name, right, result )',
-  'Operator <=(integer,text) RETURNS boolean should not exist',
+  'Operator <=(integer,text) RETURNS bool should not exist',
   ''
 );
 
@@ -1558,7 +1558,7 @@ SELECT * FROM check_test(
 -- Test has_leftop().
 
 SELECT * FROM check_test(
-  has_leftop( 'pg_catalog', '+', 'bigint', 'bigint', 'desc' ),
+  has_leftop( 'pg_catalog', '+', 'bigint', 'int8', 'desc' ),
   true,
   'has_leftop( schema, name, right, result, desc )',
   'desc',
@@ -1574,7 +1574,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_leftop( '+', 'bigint', 'bigint', 'desc' ),
+  has_leftop( '+', 'bigint', 'int8', 'desc' ),
   true,
   'has_leftop( name, right, result, desc )',
   'desc',
@@ -1582,10 +1582,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_leftop( '+', 'bigint', 'bigint'::name ),
+  has_leftop( '+', 'bigint', 'int8'::name ),
   true,
   'has_leftop( name, right, result )',
-  'Left operator +(NONE,bigint) RETURNS bigint should exist',
+  'Left operator +(NONE,bigint) RETURNS int8 should exist',
   ''
 );
 
@@ -1598,10 +1598,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_leftop( '+', 'bigint' ),
+  has_leftop( '+', 'int8' ),
   true,
   'has_leftop( name, right )',
-  'Left operator +(NONE,bigint) should exist',
+  'Left operator +(NONE,int8) should exist',
   ''
 );
 
@@ -1622,7 +1622,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_leftop( '+', 'text', 'integer', 'desc' ),
+  has_leftop( '+', 'text', 'inte', 'desc' ),
   false,
   'has_leftop( name, right, result, desc ) fail',
   'desc',
@@ -1630,10 +1630,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_leftop( '+', 'text', 'integer'::name ),
+  has_leftop( '+', 'text', 'int'::name ),
   false,
   'has_leftop( name, right, result ) fail',
-  'Left operator +(NONE,text) RETURNS integer should exist',
+  'Left operator +(NONE,text) RETURNS int should exist',
   ''
 );
 
@@ -1657,7 +1657,7 @@ SELECT * FROM check_test(
 -- Test hasnt_leftop().
 
 SELECT * FROM check_test(
-  hasnt_leftop( 'pg_catalog', '+', 'bigint', 'bigint', 'desc' ),
+  hasnt_leftop( 'pg_catalog', '+', 'bigint', 'int8', 'desc' ),
   false,
   'hasnt_leftop( schema, name, right, result, desc ) fail',
   'desc',
@@ -1665,10 +1665,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_leftop( 'pg_catalog', '+', 'bigint', 'bigint'::name ),
+  hasnt_leftop( 'pg_catalog', '+', 'bigint', 'int8'::name ),
   false,
   'hasnt_leftop( schema, name, right, result ) fail',
-  'Left operator pg_catalog.+(NONE,bigint) RETURNS bigint should not exist',
+  'Left operator pg_catalog.+(NONE,bigint) RETURNS int8 should not exist',
   ''
 );
 
@@ -1681,10 +1681,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_leftop( '+', 'bigint', 'bigint'::name ),
+  hasnt_leftop( '+', 'int8', 'int8'::name ),
   false,
   'hasnt_leftop( name, right, result ) fail',
-  'Left operator +(NONE,bigint) RETURNS bigint should not exist',
+  'Left operator +(NONE,int8) RETURNS int8 should not exist',
   ''
 );
 
@@ -1697,10 +1697,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_leftop( '+', 'bigint' ),
+  hasnt_leftop( '+', 'int8' ),
   false,
   'hasnt_leftop( name, right ) fail',
-  'Left operator +(NONE,bigint) should not exist',
+  'Left operator +(NONE,int8) should not exist',
   ''
 );
 
@@ -1729,10 +1729,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  hasnt_leftop( '+', 'text', 'bigint'::name ),
+  hasnt_leftop( '+', 'text', 'int8'::name ),
   true,
   'hasnt_leftop( name, right, result )',
-  'Left operator +(NONE,text) RETURNS bigint should not exist',
+  'Left operator +(NONE,text) RETURNS int8 should not exist',
   ''
 );
 
@@ -1793,7 +1793,7 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT * FROM check_test(
-            has_rightop( 'bigint', '!', 'desc' ),
+            has_rightop( 'int8', '!', 'desc' ),
             true,
             'has_rightop( left, name, desc )',
             'desc',
@@ -1801,10 +1801,10 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT * FROM check_test(
-            has_rightop( 'bigint', '!' ),
+            has_rightop( 'int8', '!' ),
             true,
             'has_rightop( left, name )',
-            'Right operator !(bigint,NONE) should exist',
+            'Right operator !(int8,NONE) should exist',
             ''
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
@@ -1910,7 +1910,7 @@ DECLARE
 BEGIN
     IF pg_version_num() < 140000 THEN
         FOR tap IN SELECT * FROM check_test(
-            hasnt_rightop( 'bigint', 'pg_catalog', '!', 'numeric', 'desc' ),
+            hasnt_rightop( 'int8', 'pg_catalog', '!', 'numeric', 'desc' ),
             false,
             'hasnt_rightop( left, schema, name, result, desc ) fail',
             'desc',
@@ -1926,7 +1926,7 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT * FROM check_test(
-            hasnt_rightop( 'bigint', '!', 'numeric', 'desc' ),
+            hasnt_rightop( 'int8', '!', 'numeric', 'desc' ),
             false,
             'hasnt_rightop( left, name, result, desc ) fail',
             'desc',
@@ -1942,7 +1942,7 @@ BEGIN
         ) AS b LOOP RETURN NEXT tap.b; END LOOP;
 
         FOR tap IN SELECT * FROM check_test(
-            hasnt_rightop( 'bigint', '!', 'desc' ),
+            hasnt_rightop( 'int8', '!', 'desc' ),
             false,
             'hasnt_rightop( left, name, desc ) fail',
             'desc',
@@ -2269,7 +2269,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'us_postal_code', 'pg_catalog', 'integer', 'whatever'),
+    domain_type_is( 'public', 'us_postal_code', 'pg_catalog', 'int', 'whatever'),
     false,
     'domain_type_is(schema, domain, schema, type, desc) fail',
     'whatever',
@@ -2278,7 +2278,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'zip_code', 'pg_catalog', 'integer', 'whatever'),
+    domain_type_is( 'public', 'zip_code', 'pg_catalog', 'int', 'whatever'),
     false,
     'domain_type_is(schema, nondomain, schema, type, desc)',
     'whatever',
@@ -2286,7 +2286,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'integer', 'pg_catalog', 'integer', 'whatever'),
+    domain_type_is( 'public', 'integer', 'pg_catalog', 'int', 'whatever'),
     false,
     'domain_type_is(schema, type, schema, type, desc) fail',
     'whatever',
@@ -2310,7 +2310,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'us_postal_code', 'integer', 'whatever'),
+    domain_type_is( 'public', 'us_postal_code', 'int', 'whatever'),
     false,
     'domain_type_is(schema, domain, type, desc) fail',
     'whatever',
@@ -2319,7 +2319,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'zip_code', 'integer', 'whatever'),
+    domain_type_is( 'public', 'zip_code', 'int', 'whatever'),
     false,
     'domain_type_is(schema, nondomain, type, desc)',
     'whatever',
@@ -2327,7 +2327,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'integer', 'integer', 'whatever'),
+    domain_type_is( 'public', 'integer', 'int', 'whatever'),
     false,
     'domain_type_is(schema, type, type, desc) fail',
     'whatever',
@@ -2351,7 +2351,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'us_postal_code', 'integer', 'whatever'),
+    domain_type_is( 'us_postal_code', 'int', 'whatever'),
     false,
     'domain_type_is(domain, type, desc) fail',
     'whatever',
@@ -2360,7 +2360,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'zip_code', 'integer', 'whatever'),
+    domain_type_is( 'zip_code', 'int', 'whatever'),
     false,
     'domain_type_is(nondomain, type, desc)',
     'whatever',
@@ -2368,7 +2368,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'integer', 'integer', 'whatever'),
+    domain_type_is( 'integer', 'int', 'whatever'),
     false,
     'domain_type_is(type, type, desc) fail',
     'whatever',
@@ -2376,7 +2376,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_isnt( 'public', 'us_postal_code', 'public', 'integer', 'whatever'),
+    domain_type_isnt( 'public', 'us_postal_code', 'public', 'int', 'whatever'),
     true,
     'domain_type_isnt(schema, domain, schema, type, desc)',
     'whatever',
@@ -2384,10 +2384,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_isnt( 'public', 'us_postal_code', 'pg_catalog'::name, 'integer'),
+    domain_type_isnt( 'public', 'us_postal_code', 'pg_catalog'::name, 'int4'),
     true,
     'domain_type_isnt(schema, domain, schema, type)',
-    'Domain public.us_postal_code should not extend type pg_catalog.integer',
+    'Domain public.us_postal_code should not extend type pg_catalog.int4',
     ''
 );
 
@@ -2425,10 +2425,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_isnt( 'public'::name, 'us_postal_code', 'integer'),
+    domain_type_isnt( 'public'::name, 'us_postal_code', 'int'),
     true,
     'domain_type_isnt(schema, domain, type)',
-    'Domain public.us_postal_code should not extend type integer', 
+    'Domain public.us_postal_code should not extend type int', 
     ''
 );
 
@@ -2466,10 +2466,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_isnt( 'us_postal_code', 'integer'),
+    domain_type_isnt( 'us_postal_code', 'int'),
     true,
     'domain_type_isnt(domain, type)',
-    'Domain us_postal_code should not extend type integer', 
+    'Domain us_postal_code should not extend type int', 
     ''
 );
 

--- a/tools/util.sh
+++ b/tools/util.sh
@@ -110,13 +110,6 @@ die() {
   exit $return
 }
 
-file_sanity() {
-  for file in "$@"; do
-    [ -e "$file" ] || die 1 "error: file '$file' does not exist"
-    [ -r "$file" ] || die 1 "error: file '$file' is not readable"
-  done
-}
-
 db_exists() {
     local exists
     exists=`psql -qtc "SELECT EXISTS( SELECT 1 FROM pg_database WHERE datname = '$dbname' )" postgres $@ | tr -d ' '`


### PR DESCRIPTION
Enabled by the new `_typename()` function and by the `_funkargs()` function added in 2888bb8. This means  that common aliases for standard types can be specified as, e.g., `int` and  `bool` rather than `integer` and `boolean`.

Resolves #292.

Also removed unused `file_sanity()` shell function and replaced a couple of mental health terminology references.