### PR TITLE
Remove redundant DROP FUNCTIONs

### DIFF
--- a/sql/pgtap--1.1.0--1.2.0.sql
+++ b/sql/pgtap--1.1.0--1.2.0.sql
@@ -493,14 +493,6 @@ DROP FUNCTION _agg ( NAME );
 DROP FUNCTION _agg ( NAME, NAME[] );
 DROP FUNCTION _agg ( NAME, NAME );
 DROP FUNCTION _agg ( NAME, NAME, NAME[] );
-DROP FUNCTION _agg ( NAME );
-DROP FUNCTION _agg ( NAME, NAME[] );
-DROP FUNCTION _agg ( NAME, NAME );
-DROP FUNCTION _agg ( NAME, NAME, NAME[] );
-DROP FUNCTION _agg ( NAME );
-DROP FUNCTION _agg ( NAME, NAME[] );
-DROP FUNCTION _agg ( NAME, NAME );
-DROP FUNCTION _agg ( NAME, NAME, NAME[] );
 
 -- is_normal_function( schema, function, args[], description )
 CREATE OR REPLACE FUNCTION is_normal_function ( NAME, NAME, NAME[], TEXT )


### PR DESCRIPTION
Upgrading extension from v1.1.0 to v1.2.0 fails.

The error is owing to multiple `DROP FUNCTION` calls with similar signature. The script would have succeeded if they were `DROP FUNCTION IF EXISTS`, but that seems unnecessary here.

```
postgres=# create extension pgtap version '1.1.0';
CREATE EXTENSION
postgres=# \dx
                 List of installed extensions
  Name   | Version |   Schema   |         Description
---------+---------+------------+------------------------------
 pgtap   | 1.1.0   | public     | Unit testing for PostgreSQL
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
(2 rows)

postgres=# select * from pg_available_extension_versions where name = 'pgtap';
 name  | version | installed | superuser | trusted | relocatable | schema | requires  |           comment
-------+---------+-----------+-----------+---------+-------------+--------+-----------+-----------------------------
 pgtap | 1.1.0   | t         | f         | f       | t           |        | {plpgsql} | Unit testing for PostgreSQL
 pgtap | 1.2.0   | f         | f         | f       | t           |        | {plpgsql} | Unit testing for PostgreSQL
 pgtap | 1.2.1   | f         | f         | f       | t           |        | {plpgsql} | Unit testing for PostgreSQL
(3 rows)

postgres=# alter extension pgtap update to '1.2.0';
ERROR:  function _agg(name) does not exist
```