### PR TITLE
Remove SELECT rule from test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { version: 14,  upgrade_to: "",  update_from: 0.99.0 }
+          - { version: 15,  upgrade_to: "",  update_from: 0.99.0 }
+          - { version: 14,  upgrade_to: 15,  update_from: 0.99.0 }
           - { version: 13,  upgrade_to: 14,  update_from: 0.99.0 }
           - { version: 12,  upgrade_to: 13,  update_from: 0.99.0 }
           - { version: 11,  upgrade_to: 12,  update_from: 0.99.0 } # Versions prior to 0.99.0 don't support Postgres 11
@@ -20,10 +21,9 @@ jobs:
           - { version: 9.4, upgrade_to: 9.5, update_from: 0.95.0 }
           - { version: 9.3, upgrade_to: 9.4, update_from: 0.95.0 }
           - { version: 9.2, upgrade_to: 9.3, update_from: "" }     # updatecheck is not supported prior to 9.3
-          - { version: 9.1, upgrade_to: 9.2, update_from: "" }
           # Also test pg_upgrade across many versions
-          - { version: 9.1,  upgrade_to: 14, update_from: "", suffix: –14 }
-          - { version: 9.4,  upgrade_to: 14, update_from: "", suffix: –14 }
+          - { version: 9.2,  upgrade_to: 15, update_from: "", suffix: –15 }
+          - { version: 9.4,  upgrade_to: 15, update_from: "", suffix: –15 }
     name: 🐘 PostgreSQL ${{ matrix.version }}${{ matrix.suffix }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools

--- a/Changes
+++ b/Changes
@@ -23,6 +23,9 @@ Revision history for pgTAP
 * Removed redundant `DROP` statements from the 1.2.0 upgrade script that
   prevented upgrades from working properly. Thanks to @robins for the PR
   (#300)!
+* Fixed a test failure caused by the removal of support for select rules in
+  postgres/postgres@b23cd18 (expected in Postgres 16). Thanks to @Deltaus for
+  the report (#309)!
 
 1.2.0 2021-12-05T18:08:13Z
 --------------------------

--- a/test/expected/ruletap.out
+++ b/test/expected/ruletap.out
@@ -72,9 +72,9 @@ ok 69 - rule_is_on(schema, table, rule, insert, desc) should have the proper dia
 ok 70 - rule_is_on(schema, table, rule, update, desc) should pass
 ok 71 - rule_is_on(schema, table, rule, update, desc) should have the proper description
 ok 72 - rule_is_on(schema, table, rule, update, desc) should have the proper diagnostics
-ok 73 - rule_is_on(schema, table, rule, SELECT, desc) should pass
-ok 74 - rule_is_on(schema, table, rule, SELECT, desc) should have the proper description
-ok 75 - rule_is_on(schema, table, rule, SELECT, desc) should have the proper diagnostics
+ok 73 - rule_is_on(schema, table, rule, insert, desc) should pass
+ok 74 - rule_is_on(schema, table, rule, insert, desc) should have the proper description
+ok 75 - rule_is_on(schema, table, rule, insert, desc) should have the proper diagnostics
 ok 76 - rule_is_on(schema, table, rule, delete, desc) should pass
 ok 77 - rule_is_on(schema, table, rule, delete, desc) should have the proper description
 ok 78 - rule_is_on(schema, table, rule, delete, desc) should have the proper diagnostics
@@ -105,9 +105,9 @@ ok 102 - rule_is_on(table, rule, insert, desc) should have the proper diagnostic
 ok 103 - rule_is_on(table, rule, update, desc) should pass
 ok 104 - rule_is_on(table, rule, update, desc) should have the proper description
 ok 105 - rule_is_on(table, rule, update, desc) should have the proper diagnostics
-ok 106 - rule_is_on(table, rule, SELECT, desc) should pass
-ok 107 - rule_is_on(table, rule, SELECT, desc) should have the proper description
-ok 108 - rule_is_on(table, rule, SELECT, desc) should have the proper diagnostics
+ok 106 - rule_is_on(table, rule, insert, desc) should pass
+ok 107 - rule_is_on(table, rule, insert, desc) should have the proper description
+ok 108 - rule_is_on(table, rule, insert, desc) should have the proper diagnostics
 ok 109 - rule_is_on(table, rule, delete, desc) should pass
 ok 110 - rule_is_on(table, rule, delete, desc) should have the proper description
 ok 111 - rule_is_on(table, rule, delete, desc) should have the proper diagnostics

--- a/test/sql/ruletap.sql
+++ b/test/sql/ruletap.sql
@@ -15,8 +15,9 @@ CREATE TABLE public.sometab(
 CREATE RULE ins_me AS ON INSERT TO public.sometab DO NOTHING;
 CREATE RULE upd_me AS ON UPDATE TO public.sometab DO ALSO SELECT now();
 
-CREATE TABLE public.toview ( id INT );
-CREATE RULE "_RETURN" AS ON SELECT TO public.toview DO INSTEAD SELECT 42 AS id;
+CREATE TABLE public.sprockets ( id INT );
+CREATE RULE ins_me AS ON INSERT TO public.sprockets DO INSTEAD NOTHING;
+CREATE RULE del_me AS ON delete TO public.sprockets DO INSTEAD NOTHING;
 
 CREATE TABLE public.widgets (id int);
 CREATE RULE del_me AS ON DELETE TO public.widgets DO NOTHING;
@@ -127,7 +128,7 @@ SELECT * FROM check_test(
 -- Test rule_is_instead().
 
 SELECT * FROM check_test(
-    rule_is_instead( 'public', 'toview', '_RETURN', 'whatever' ),
+    rule_is_instead( 'public', 'sprockets', 'ins_me', 'whatever' ),
     true,
     'rule_is_instead(schema, table, rule, desc)',
     'whatever',
@@ -135,10 +136,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    rule_is_instead( 'public', 'toview', '_RETURN'::name ),
+    rule_is_instead( 'public', 'sprockets', 'ins_me'::name ),
     true,
     'rule_is_instead(schema, table, rule)',
-    'Rule "_RETURN" on relation public.toview should be an INSTEAD rule',
+    'Rule ins_me on relation public.sprockets should be an INSTEAD rule',
     ''
 );
 
@@ -159,7 +160,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    rule_is_instead( 'toview', '_RETURN', 'whatever' ),
+    rule_is_instead( 'sprockets', 'ins_me', 'whatever' ),
     true,
     'rule_is_instead(table, rule, desc)',
     'whatever',
@@ -167,10 +168,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    rule_is_instead( 'toview', '_RETURN'::name ),
+    rule_is_instead( 'sprockets', 'ins_me'::name ),
     true,
     'rule_is_instead(table, rule)',
-    'Rule "_RETURN" on relation toview should be an INSTEAD rule',
+    'Rule ins_me on relation sprockets should be an INSTEAD rule',
     ''
 );
 
@@ -226,9 +227,9 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    rule_is_on( 'public', 'toview', '_RETURN', 'SELECT', 'whatever' ),
+    rule_is_on( 'public', 'sprockets', 'ins_me', 'insert', 'whatever' ),
     true,
-    'rule_is_on(schema, table, rule, SELECT, desc)',
+    'rule_is_on(schema, table, rule, insert, desc)',
     'whatever',
     ''
 );
@@ -315,9 +316,9 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    rule_is_on( 'toview', '_RETURN', 'SELECT', 'whatever' ),
+    rule_is_on( 'sprockets', 'ins_me', 'insert', 'whatever' ),
     true,
-    'rule_is_on(table, rule, SELECT, desc)',
+    'rule_is_on(table, rule, insert, desc)',
     'whatever',
     ''
 );


### PR DESCRIPTION
It was not necessary to test the rule functions, and was present just to be sure that they worked with select rules. But the removal of select rules in postgres/postgres@b23cd18 breaks the test, so just use an ON INSERT rule to ensure that `rule_is_instead()` works. Resolves #309.

Also add Postgres 15 as a test target and remove 9.1 upgrade test, which apparently is no longer supported.
