### PR TITLE
Fix `col_type_is` with `want_type` `INTERVAL SECOND(0)`

### DIFF
--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1489,6 +1489,14 @@ BEGIN
         );
     END IF;
 
+    -- Check want_type as provided before trying the resolved type name
+    -- (see https://github.com/theory/pgtap/issues/315).
+    want_type := quote_ident($4) || '.' || $5;
+    IF have_type = want_type THEN
+        -- We're good to go.
+        RETURN ok( true, $6 );
+    END IF;
+
     want_type := quote_ident($4) || '.' || _quote_ident_like($5, have_type);
     IF have_type = want_type THEN
         -- We're good to go.
@@ -1529,6 +1537,14 @@ BEGIN
             '   Column ' || COALESCE(quote_ident($1) || '.', '')
             || quote_ident($2) || '.' || quote_ident($3) || ' does not exist'
         );
+    END IF;
+
+    -- Check want_type as provided before trying the resolved type name
+    -- (see https://github.com/theory/pgtap/issues/315).
+    want_type := $4;
+    IF have_type = want_type THEN
+        -- We're good to go.
+        RETURN ok( true, $5 );
     END IF;
 
     want_type := _quote_ident_like($4, have_type);

--- a/test/expected/coltap.out
+++ b/test/expected/coltap.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..243
+1..249
 ok 1 - col_not_null( sch, tab, col, desc ) should pass
 ok 2 - col_not_null( sch, tab, col, desc ) should have the proper description
 ok 3 - col_not_null( sch, tab, col, desc ) should have the proper diagnostics
@@ -243,3 +243,9 @@ ok 240 - col_default_is( tab, col, LOCALTIME ) should have the proper diagnostic
 ok 241 - col_default_is( tab, col, LOCALTIMESTAMP ) should pass
 ok 242 - col_default_is( tab, col, LOCALTIMESTAMP ) should have the proper description
 ok 243 - col_default_is( tab, col, LOCALTIMESTAMP ) should have the proper diagnostics
+ok 244 - col_type_is with interval second(0) should pass
+ok 245 - col_type_is with interval second(0) should have the proper description
+ok 246 - col_type_is with interval second(0) should have the proper diagnostics
+ok 247 - col_type_is with pg_catalog.interval second(0) should pass
+ok 248 - col_type_is with pg_catalog.interval second(0) should have the proper description
+ok 249 - col_type_is with pg_catalog.interval second(0) should have the proper diagnostics

--- a/test/sql/coltap.sql
+++ b/test/sql/coltap.sql
@@ -1,7 +1,7 @@
 \unset ECHO
 \i test/setup.sql
 
-SELECT plan(243);
+SELECT plan(249);
 --SELECT * from no_plan();
 
 CREATE TYPE public."myType" AS (
@@ -29,7 +29,8 @@ CREATE TABLE public.sometab(
     ltime   TIME DEFAULT LOCALTIME,
     ltstz   TIMESTAMPTZ DEFAULT LOCALTIMESTAMP,
     plain   INTEGER,
-    camel   "myType"
+    camel   "myType",
+    ivsec   INTERVAL SECOND(0)
 );
 
 CREATE OR REPLACE FUNCTION fakeout( eok boolean, name text )
@@ -652,6 +653,22 @@ BEGIN
 END;
 $$;
 SELECT * FROM ckreserve();
+
+SELECT * FROM check_test(
+    col_type_is( 'sometab', 'ivsec', 'interval second(0)', 'should be interval second(0)' ),
+    true,
+    'col_type_is with interval second(0)',
+    'should be interval second(0)',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_type_is( 'public', 'sometab', 'ivsec', 'pg_catalog', 'interval second(0)', 'should be interval second(0)' ),
+    true,
+    'col_type_is with pg_catalog.interval second(0)',
+    'should be interval second(0)',
+    ''
+);
 
 /****************************************************************************/
 -- Finish the tests and clean up.


### PR DESCRIPTION
Check `have_type` against the provided `want_type` before trying the resolved type name.  The problem is that type `INTERVAL SECOND(0)` is resolved to just `INTERVAL(0)` by `_quote_ident_like(text, text)` since commit 1e1d745.

Resolves #315.