### PR TITLE
Replace _quote_ident_like() with _typename()

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,14 @@ Revision history for pgTAP
 * Removed the documentation for `pg_typeof()`, which was removed from pgTAP
   when support for PostgreSQL 8.3 was dropped, since the same function has
   been available in the PostgreSQL core since then.
+* Improved the support for type name aliases to the following functions:
+    * `has_cast()`
+    * `hasnt_cast()`
+    * `cast_context_is()`
+    * `domain_type_is()`
+    * `domain_type_isnt()`
+    * `has_operator()`
+    * `hasnt_operator()`
 
 1.3.0 2023-08-14T22:14:20Z
 --------------------------

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -3834,13 +3834,15 @@ resolve the function name as a description. For example:
 
 pgTAP will generate a useful description if you don't provide one.
 
-Note that pgTAP does not compare typemods. So if you wanted to test for a cast
-between, say, a `uuid` type and `bit(128)`, this will not work:
+Types can be defined by their canonical names or their aliases,
+e.g., `character varying` or `varchar`, so both these tests will pass:
+
+    SELECT has_cast( 'text', 'character varying' );
+    SELECT has_cast( 'text', 'varchar' );
+
+Note that pgTAP ignores typemods, so either of these tests will pass:
 
     SELECT has_cast( 'integer', 'bit(128)' );
-
-But this will:
-
     SELECT has_cast( 'integer', 'bit' );
 
 ### `hasnt_cast()` ###
@@ -3906,6 +3908,10 @@ given schema, name, left and right arguments, and return value, the test will
 pass. If the operator does not exist, the test will fail. Example:
 
     SELECT has_operator( 'integer', 'pg_catalog', '<=', 'integer', 'boolean' );
+
+Types can be defined by their canonical names or their aliases, e.g.,
+`timestamp with time zone` or `timestamptz`, or `character varying` or
+`varchar`.
 
 If you omit the schema name, then the operator must be visible in the search
 path. If you omit the test description, pgTAP will generate a reasonable one
@@ -6139,7 +6145,7 @@ omit the test description, it will be set to "Enum `:enum` should have labels
 `:description`
 : A short description of the test.
 
-Tests the data type underlying a domain. The first two   arguments are the
+Tests the data type underlying a domain. The first two arguments are the
 schema and name of the domain. The second two are the schema and name of the
 type that the domain should extend. The fifth argument is a description. If
 there is no description, a reasonable default description will be created.
@@ -6147,6 +6153,10 @@ there is no description, a reasonable default description will be created.
 The schema arguments are also optional. However, if there is no `:schema`
 argument, there cannot be a `:type_schema` argument, either, though the
 schema can be included in the `type` argument, e.g., `contrib.citext`.
+
+Types can be defined by their canonical names or their aliases, e.g.,
+`timestamp with time zone` or `timestamptz`, or `character varying` or
+`varchar`.
 
 For the 3- and 4-argument forms with schemas, cast the schemas to `NAME` to
 avoid ambiguities. Example:
@@ -6229,12 +6239,14 @@ Example:
 
     SELECT cast_context_is( 'integer', 'bigint', 'implicit' );
 
-The data types should be passed as they are displayed by
-`pg_catalog.format_type()`. For example, you would need to pass "character
-varying", and not "VARCHAR".
+The data types may be defined by their canonical names or their aliases,
+e.g., `character varying` or `varchar`, so both these tests will pass:
 
-The The supported contexts are "implicit", "assignment", and "explicit". You
-can also just pass in "i", "a", or "e". Consult the PostgreSQL [`CREATE
+    SELECT cast_context_is( 'text', 'character varying', 'implicit' );
+    SELECT cast_context_is( 'text', 'varchar', 'implicit' );
+
+The supported contexts are "implicit", "assignment", and "explicit". You can
+also just pass in "i", "a", or "e". Consult the PostgreSQL [`CREATE
 CAST`](https://www.postgresql.org/docs/current/static/sql-createcast.html)
 documentation for the differences between these contexts (hint: they
 correspond to the default context, `AS IMPLICIT`, and `AS ASSIGNMENT`). If you

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1473,20 +1473,6 @@ EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;
 
-CREATE OR REPLACE FUNCTION _quote_ident_like(TEXT, TEXT)
-RETURNS TEXT AS $$
-DECLARE
-    typname TEXT := _typename($1);
-    pcision TEXT := COALESCE(substring($1 FROM '[(][^")]+[)]$'), '');
-BEGIN
-    -- Just return it if rhs isn't quoted.
-    IF $2 !~ '"' THEN RETURN typname || pcision; END IF;
-
-    -- Otherwise return it with the type part quoted.
-    RETURN quote_ident(typname) || pcision;
-END;
-$$ LANGUAGE plpgsql;
-
 -- col_type_is( schema, table, column, schema, type, description )
 CREATE OR REPLACE FUNCTION col_type_is ( NAME, NAME, NAME, NAME, TEXT, TEXT )
 RETURNS TEXT AS $$
@@ -4088,12 +4074,8 @@ $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _cmp_types(oid, name)
 RETURNS BOOLEAN AS $$
-DECLARE
-    dtype TEXT := pg_catalog.format_type($1, NULL);
-BEGIN
-    RETURN dtype = _quote_ident_like($2, dtype);
-END;
-$$ LANGUAGE plpgsql;
+    SELECT pg_catalog.format_type($1, NULL) = _typename($2);
+$$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION _cast_exists ( NAME, NAME, NAME, NAME )
 RETURNS BOOLEAN AS $$
@@ -7843,7 +7825,10 @@ BEGIN
         );
     END IF;
 
-    RETURN is( actual_type, quote_ident($3) || '.' || _quote_ident_like($4, actual_type), $5 );
+    IF quote_ident($3) = ANY(current_schemas(true)) THEN
+        RETURN is( actual_type, quote_ident($3) || '.' || _typename($4), $5);
+    END IF;
+    RETURN is( actual_type, _typename(quote_ident($3) || '.' || $4), $5);
 END;
 $$ LANGUAGE plpgsql;
 
@@ -7870,7 +7855,7 @@ BEGIN
         );
     END IF;
 
-    RETURN is( actual_type, _quote_ident_like($3, actual_type), $4 );
+    RETURN is( actual_type, _typename($3), $4 );
 END;
 $$ LANGUAGE plpgsql;
 
@@ -7896,7 +7881,7 @@ BEGIN
         );
     END IF;
 
-    RETURN is( actual_type, _quote_ident_like($2, actual_type), $3 );
+    RETURN is( actual_type, _typename($2), $3 );
 END;
 $$ LANGUAGE plpgsql;
 
@@ -7922,7 +7907,10 @@ BEGIN
         );
     END IF;
 
-    RETURN isnt( actual_type, quote_ident($3) || '.' || _quote_ident_like($4, actual_type), $5 );
+    IF quote_ident($3) = ANY(current_schemas(true)) THEN
+        RETURN isnt( actual_type, quote_ident($3) || '.' || _typename($4), $5);
+    END IF;
+    RETURN isnt( actual_type, _typename(quote_ident($3) || '.' || $4), $5);
 END;
 $$ LANGUAGE plpgsql;
 
@@ -7949,7 +7937,7 @@ BEGIN
         );
     END IF;
 
-    RETURN isnt( actual_type, _quote_ident_like($3, actual_type), $4 );
+    RETURN isnt( actual_type, _typename($3), $4 );
 END;
 $$ LANGUAGE plpgsql;
 
@@ -7975,7 +7963,7 @@ BEGIN
         );
     END IF;
 
-    RETURN isnt( actual_type, _quote_ident_like($2, actual_type), $3 );
+    RETURN isnt( actual_type, _typename($2), $3 );
 END;
 $$ LANGUAGE plpgsql;
 

--- a/test/sql/hastap.sql
+++ b/test/sql/hastap.sql
@@ -1,5 +1,6 @@
 \unset ECHO
 \i test/setup.sql
+-- \i sql/pgtap.sql
 
 SELECT plan(1004);
 --SELECT * FROM no_plan();
@@ -47,7 +48,6 @@ CREATE DOMAIN public.us_postal_code AS TEXT CHECK(
 CREATE DOMAIN public."myDomain" AS TEXT CHECK(TRUE);
 
 CREATE SEQUENCE public.someseq;
-
 
 CREATE SCHEMA someschema;
 RESET client_min_messages;
@@ -1109,10 +1109,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    has_cast( 'integer', 'bigint', 'pg_catalog', 'int8'::name),
+    has_cast( 'int4', 'BIGINT', 'pg_catalog', 'int8'::name),
     true,
     'has_cast( src, targ, schema, func )',
-    'Cast ("integer" AS "bigint") WITH FUNCTION pg_catalog.int8() should exist',
+    'Cast (int4 AS "BIGINT") WITH FUNCTION pg_catalog.int8() should exist',
     ''
 );
 
@@ -1125,10 +1125,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    has_cast( 'integer', 'bigint', 'int8'::name),
+    has_cast( 'INT4', 'BIGINT', 'int8'::name),
     true,
     'has_cast( src, targ, func)',
-    'Cast ("integer" AS "bigint") WITH FUNCTION int8() should exist',
+    'Cast ("INT4" AS "BIGINT") WITH FUNCTION int8() should exist',
     ''
 );
 
@@ -1141,10 +1141,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    has_cast( 'integer', 'bigint' ),
+    has_cast( 'int4', 'BIGINT' ),
     true,
     'has_cast( src, targ )',
-    'Cast ("integer" AS "bigint") should exist',
+    'Cast (int4 AS "BIGINT") should exist',
     ''
 );
 
@@ -1157,7 +1157,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    has_cast( 'integer', 'bigint', 'foo', 'desc' ),
+    has_cast( 'INT4', 'BIGINT', 'foo', 'desc' ),
     false,
     'has_cast( src, targ, func, desc ) fail',
     'desc',
@@ -1184,10 +1184,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    hasnt_cast( 'integer', 'bigint', 'pg_catalog', 'int8'::name),
+    hasnt_cast( 'int4', 'int8', 'pg_catalog', 'int8'::name),
     false,
     'hasnt_cast( src, targ, schema, func )',
-    'Cast ("integer" AS "bigint") WITH FUNCTION pg_catalog.int8() should not exist',
+    'Cast (int4 AS int8) WITH FUNCTION pg_catalog.int8() should not exist',
     ''
 );
 
@@ -1200,10 +1200,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    hasnt_cast( 'integer', 'bigint', 'int8'::name),
+    hasnt_cast( 'INT4', 'INT8', 'int8'::name),
     false,
     'hasnt_cast( src, targ, func)',
-    'Cast ("integer" AS "bigint") WITH FUNCTION int8() should not exist',
+    'Cast ("INT4" AS "INT8") WITH FUNCTION int8() should not exist',
     ''
 );
 
@@ -1216,10 +1216,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    hasnt_cast( 'integer', 'bigint' ),
+    hasnt_cast( 'int4', 'int8' ),
     false,
     'hasnt_cast( src, targ )',
-    'Cast ("integer" AS "bigint") should not exist',
+    'Cast (int4 AS int8) should not exist',
     ''
 );
 
@@ -1232,7 +1232,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    hasnt_cast( 'integer', 'bigint', 'foo', 'desc' ),
+    hasnt_cast( 'INT4', 'INT8', 'foo', 'desc' ),
     true,
     'hasnt_cast( src, targ, func, desc ) fail',
     'desc',
@@ -1259,10 +1259,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'integer', 'bigint', 'implicit' ),
+    cast_context_is( 'int4', 'int8', 'implicit' ),
     true,
     'cast_context_is( src, targ, context )',
-    'Cast ("integer" AS "bigint") context should be implicit',
+    'Cast (int4 AS int8) context should be implicit',
     ''
 );
 
@@ -1275,7 +1275,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'integer', 'bigint', 'IMPL', 'desc' ),
+    cast_context_is( 'INT4', 'INT8', 'IMPL', 'desc' ),
     true,
     'cast_context_is( src, targ, IMPL, desc )',
     'desc',
@@ -1291,7 +1291,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'bigint', 'smallint', 'a', 'desc' ),
+    cast_context_is( 'int4', 'int2', 'a', 'desc' ),
     true,
     'cast_context_is( src, targ, a, desc )',
     'desc',
@@ -1307,7 +1307,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'bit', 'integer', 'explicit', 'desc' ),
+    cast_context_is( 'bit(128)', 'integer', 'explicit', 'desc' ),
     true,
     'cast_context_is( src, targ, explicit, desc )',
     'desc',
@@ -1315,7 +1315,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'bit', 'integer', 'e', 'desc' ),
+    cast_context_is( 'bit', 'int4', 'e', 'desc' ),
     true,
     'cast_context_is( src, targ, e, desc )',
     'desc',
@@ -1331,7 +1331,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'integer', 'bigint', 'ex', 'desc' ),
+    cast_context_is( 'integer', 'int8', 'ex', 'desc' ),
     false,
     'cast_context_is( src, targ, context, desc ) fail',
     'desc',
@@ -1340,10 +1340,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    cast_context_is( 'integer', 'bigint', 'ex' ),
+    cast_context_is( 'INT4', 'INT8', 'ex' ),
     false,
     'cast_context_is( src, targ, context ) fail',
-    'Cast ("integer" AS "bigint") context should be explicit',
+    'Cast ("INT4" AS "INT8") context should be explicit',
     '        have: implicit
         want: explicit'
 );
@@ -1368,10 +1368,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', 'pg_catalog', '<=', 'integer', 'boolean'::name ),
+  has_operator( 'int4', 'pg_catalog', '<=', 'integer', 'boolean'::name ),
   true,
   'has_operator( left, schema, name, right, result )',
-  'Operator pg_catalog.<=(integer,integer) RETURNS boolean should exist',
+  'Operator pg_catalog.<=(int4,integer) RETURNS boolean should exist',
   ''
 );
 
@@ -1384,10 +1384,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', '<=', 'integer', 'boolean'::name ),
+  has_operator( 'integer', '<=', 'int4', 'boolean'::name ),
   true,
   'has_operator( left, name, right, result )',
-  'Operator <=(integer,integer) RETURNS boolean should exist',
+  'Operator <=(integer,int4) RETURNS boolean should exist',
   ''
 );
 
@@ -1400,10 +1400,10 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-  has_operator( 'integer', '<=', 'integer'::name ),
+  has_operator( 'integer', '<=', 'int4'::name ),
   true,
   'has_operator( left, name, right )',
-  'Operator <=(integer,integer) should exist',
+  'Operator <=(integer,int4) should exist',
   ''
 );
 
@@ -2269,7 +2269,7 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
-    domain_type_is( 'public', 'us_postal_code', 'pg_catalog', 'int', 'whatever'),
+    domain_type_is( 'public', 'us_postal_code', 'pg_catalog', 'int4', 'whatever'),
     false,
     'domain_type_is(schema, domain, schema, type, desc) fail',
     'whatever',


### PR DESCRIPTION
This function returns the canonical data type name, without typemod, allowing any alias to be used. Testers are no longer limited to spelling out `character varying` or `timestamp with time zone`; they can now use `varchar` or `timestamptz` or any other alias.

Done by replacing all uses of the hacky old `_quote_ident_like()` function, now removed, with `_typename()`. This impacts the following test functions:

*   `has_cast()`
*   `hasnt_cast()`
*   `cast_context_is()`
*   `domain_type_is()`
*   `domain_type_isnt()`
*   `has_operator()`
*   `hasnt_operator()`

Update the documentation to reflect this change.