### PR TITLE
[Bug Fix] Fix ALTER EXTENSION UPDATE failure from 1.2.0 to 1.3.0+

### DIFF
--- a/sql/pgtap--1.2.0--1.3.0.sql
+++ b/sql/pgtap--1.2.0--1.3.0.sql
@@ -181,6 +181,8 @@ RETURNS TEXT AS $$
         ),
         $2
     );
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION _lang ( NAME, NAME, NAME[] )
 RETURNS NAME AS $$
     SELECT l.lanname


### PR DESCRIPTION
Hi, I found a bug when upgrading pgtap from 1.2.0 to 1.3.0+
```
postgres=> select * from pg_available_extensions where name = 'pgtap';
 name  | default_version | installed_version |           comment
-------+-----------------+-------------------+-----------------------------
 pgtap | 1.3.4           | 1.2.0             | Unit testing for PostgreSQL
(1 row)

postgres=> ALTER EXTENSION pgtap UPDATE;
ERROR:  syntax error at or near "SELECT"
```
Error is caused by https://github.com/theory/pgtap/blob/main/sql/pgtap--1.2.0--1.3.0.sql#L183. After the patch, it can upgrade successfully
```
postgres=> ALTER EXTENSION pgtap UPDATE;
ALTER EXTENSION
```
I also verified regression tests with the upgraded pgtap extension
```
make installcheck

1..39
# All 39 tests passed.
```
Let me know if the fix makes sense, thanks!