### PR TITLE
Remove $libdir prefix, test Pg18, update README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { version: 17,  upgrade_to: "",  update_from: 0.99.0 }
+          - { version: 18,  upgrade_to: "",  update_from: 0.99.0 }
+          - { version: 17,  upgrade_to: 18,  update_from: 0.99.0 }
           - { version: 16,  upgrade_to: 17,  update_from: 0.99.0 }
           - { version: 15,  upgrade_to: 16,  update_from: 0.99.0 }
           - { version: 14,  upgrade_to: 15,  update_from: 0.99.0 }
@@ -25,8 +26,8 @@ jobs:
           - { version: 9.2, upgrade_to: 9.3, update_from: "" }     # updatecheck is not supported prior to 9.3
           - { version: 9.1, upgrade_to: 9.2, update_from: "" }     # updatecheck is not supported prior to 9.3
           # Also test pg_upgrade across many versions
-          - { version: 9.2,  upgrade_to: 17, update_from: "", suffix: –17 }
-          - { version: 9.4,  upgrade_to: 17, update_from: "", suffix: –17 }
+          - { version: 9.2,  upgrade_to: 18, update_from: "", suffix: –18 }
+          - { version: 9.4,  upgrade_to: 18, update_from: "", suffix: –18 }
     name: 🐘 PostgreSQL ${{ matrix.version }}${{ matrix.suffix }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools

--- a/Changes
+++ b/Changes
@@ -10,6 +10,9 @@ Revision history for pgTAP
   to Jim Nasby for reporting the issue (#234) Rodolphe Quiédeville for for the
   pull request (#339).
 * Added `index_is_partial()`, thanks to Rodolphe Quiédeville (#342).
+* Removed the `$libdir/` prefix from the `module_pathname` directive, so that
+  the module can be installed and found in any directory listed in
+  `dynamic_library_path`.
 
 1.3.3 2024-04-08T13:44:11Z
 --------------------------

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ endif
 ifeq ($(shell echo $(VERSION) | grep -qE "^(9[.][01]|8[.][1234])" && echo yes || echo no),yes)
 	patch -p0 < compat/install-9.1.patch
 endif
-	sed -e 's,MODULE_PATHNAME,$$libdir/pgtap,g' -e 's,__OS__,$(OSNAME),g' -e 's,__VERSION__,$(NUMVERSION),g' sql/pgtap.sql > sql/pgtap.tmp
+	sed -e 's,MODULE_PATHNAME,pgtap,g' -e 's,__OS__,$(OSNAME),g' -e 's,__VERSION__,$(NUMVERSION),g' sql/pgtap.sql > sql/pgtap.tmp
 	mv sql/pgtap.tmp sql/pgtap.sql
 
 # Ugly hacks for now... TODO: script that understands $VERSION and will apply all the patch files for that version

--- a/README.md
+++ b/README.md
@@ -17,74 +17,114 @@ be installed remotely.
 
 To build it, just do this:
 
-    make
-    make install
-    make installcheck
+```sh
+make
+make install
+make installcheck
+```
 
 If you encounter an error such as:
 
-    "Makefile", line 8: Need an operator
+```
+"Makefile", line 8: Need an operator
+```
 
 You need to use GNU make, which may well be installed on your system as
 `gmake`:
 
-    gmake
-    gmake install
-    gmake installcheck
+```sh
+gmake
+gmake install
+gmake installcheck
+```
 
 If you encounter an error such as:
 
-    make: pg_config: Command not found
-
+```
+make: pg_config: Command not found
+```
 Or:
 
-    Makefile:52: *** pgTAP requires PostgreSQL 9.1 or later. This is .  Stop.
+```
+Makefile:52: *** pgTAP requires PostgreSQL 9.1 or later. This is .  Stop.
+```
 
 Be sure that you have `pg_config` installed and in your path. If you used a
 package management system such as RPM to install PostgreSQL, be sure that the
 `-devel` package is also installed. If necessary tell the build process where
 to find it:
 
-    env PG_CONFIG=/path/to/pg_config make && make install && make installcheck
+```sh
+env PG_CONFIG=/path/to/pg_config make && make install && make installcheck
+```
 
 And finally, if all that fails, copy the entire distribution directory to the
 `contrib/` subdirectory of the PostgreSQL source tree and try it there without
 `pg_config`:
 
-    env NO_PGXS=1 make && make install && make installcheck
+```sh
+env NO_PGXS=1 make && make install && make installcheck
+```
 
 If you encounter an error such as:
 
-    ERROR:  must be owner of database regression
+```
+ERROR:  must be owner of database regression
+```
 
 You need to run the test suite using a super user, such as the default
 "postgres" super user:
 
-    make installcheck PGUSER=postgres
+```
+make installcheck PGUSER=postgres
+```
 
 If you encounter an error such as:
 
-    ERROR: Missing extensions required for testing: citext isn ltree
+```
+ERROR: Missing extensions required for testing: citext isn ltree
+```
 
 Install the PostgreSQL
 [Additional Supplied Modules](https://www.postgresql.org/docs/current/contrib.html),
 which are required to run the tests. If you used a package management system
 such as RPM to install PostgreSQL, install the `-contrib` package.
 
+To install the extension in a custom prefix on PostgreSQL 18 or later, pass
+the `prefix` argument to `install` (but no other `make` targets):
+
+```sh
+make install prefix=/usr/local/extras
+```
+
+Then ensure that the prefix is included in the following [`postgresql.conf`
+parameters]:
+
+```ini
+extension_control_path = '/usr/local/extras/postgresql/share:$system'
+dynamic_library_path   = '/usr/local/extras/postgresql/lib:$libdir'
+```
+
 Once pgTAP is installed, you can add it to a database by connecting as a super
 user and running:
 
-    CREATE EXTENSION pgtap;
+```sql
+CREATE EXTENSION pgtap;
+```
 
 If you've upgraded your cluster to PostgreSQL 9.1 and already had pgTAP
 installed, you can upgrade it to a properly packaged extension with:
 
-    CREATE EXTENSION pgtap FROM unpackaged;
+```sql
+CREATE EXTENSION pgtap FROM unpackaged;
+```
 
 If you want to install pgTAP and all of its supporting objects into a specific
 schema, use the `SCHEMA` clause to specify the schema, like so:
 
-    CREATE EXTENSION pgtap SCHEMA tap;
+```sql
+CREATE EXTENSION pgtap SCHEMA tap;
+```
 
 Dependencies
 ------------
@@ -94,7 +134,7 @@ pgTAP requires PostgreSQL 9.1 or higher.
 Copyright and License
 ---------------------
 
-Copyright (c) 2008-2023 David E. Wheeler. Some rights reserved.
+Copyright (c) 2008-2025 David E. Wheeler. Some rights reserved.
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement is

--- a/doc/pgtap.mmd
+++ b/doc/pgtap.mmd
@@ -8827,7 +8827,7 @@ Credits
 Copyright and License
 ---------------------
 
-Copyright (c) 2008-2023 David E. Wheeler. Some rights reserved.
+Copyright (c) 2008-2025 David E. Wheeler. Some rights reserved.
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement is

--- a/pgtap.control
+++ b/pgtap.control
@@ -1,7 +1,7 @@
 # pgTAP extension
 comment = 'Unit testing for PostgreSQL'
 default_version = '1.3.4'
-module_pathname = '$libdir/pgtap'
+module_pathname = 'pgtap'
 requires = 'plpgsql'
 relocatable = true
 superuser = false

--- a/sql/pgtap--1.3.0--1.3.1.sql
+++ b/sql/pgtap--1.3.0--1.3.1.sql
@@ -1,6 +1,6 @@
 CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
 RETURNS RECORD
-AS '$libdir/pgtap'
+AS 'pgtap'
 LANGUAGE C STABLE STRICT;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )

--- a/test/expected/runtests_5.out
+++ b/test/expected/runtests_5.out
@@ -17,7 +17,7 @@ ok 3 - whatever."test ident"
     ok 3 - setup more
     # Test died: 22012: division by zero
     #         CONTEXT:
-    #             SQL function "testdividebyzero" statement 1
+    #             SQL function "testdividebyzero" during startup
     #             PL/pgSQL function _runner(text[],text[],text[],text[],text[]) line 62 at FOR over EXECUTE statement
     #             SQL function "runtests" statement 1
     #             SQL function "runtests" statement 1
@@ -108,7 +108,7 @@ ok 3 - whatever."test ident"
     ok 3 - setup more
     # Test died: 22012: division by zero
     #         CONTEXT:
-    #             SQL function "testdividebyzero" statement 1
+    #             SQL function "testdividebyzero" during startup
     #             PL/pgSQL function _runner(text[],text[],text[],text[],text[]) line 62 at FOR over EXECUTE statement
     #             SQL function "runtests" statement 1
 not ok 4 - whatever.testdividebyzero

--- a/test/test_MVU.sh
+++ b/test/test_MVU.sh
@@ -187,6 +187,14 @@ else
     new_pg_upgrade=$(find_at_path "$NEW_PATH" pg_upgrade)
 fi
 
+# Postgres 18 enables checksums by default, so turn them off to be compatible
+# with earlier versions, where they're off by default.
+if [ "$OLD_VERSION" -ge 18 ]; then
+    old_initdb+=" --no-data-checksums"
+fi
+if [ "$NEW_VERSION" -ge 18 ]; then
+    new_initdb+=" --no-data-checksums"
+fi
 
 ##################################################################################################
 banner "Creating old version temporary installation at $old_dir on port $OLD_PORT (in the background)"


### PR DESCRIPTION
Remove the `$libdir/` prefix from `module_pathname`; pgTAP does not currently install a shared module, but future-proof it.

While at it, document how to install the extension under a custom prefix on Postgres 18, and test it on Postgres 18. Also use fenced code blocks in the README.