### PR TITLE
Restore upgrade testing to CI and fix upgrades

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - run: pg-build-test
 
       # Test update.
-      - run: 'if [ -d "$UPDATE_FROM" ]; then make uninstall clean updatecheck; fi'
+      - run: 'if [ -n "$UPDATE_FROM" ]; then make uninstall clean updatecheck; fi'
 
       # Test all, install, test, test-serial, and test-parallel, both from clean
       # repo and repeated with existing build, with and without PARALLEL_CONN=1.

--- a/Changes
+++ b/Changes
@@ -15,6 +15,8 @@ Revision history for pgTAP
   `dynamic_library_path`.
 * Tested on PostgreSQL 9.1–18 and fixed a test failure on PostgreSQL 18.
 * Improved Markdown formatting in `README.md`.
+* Restored upgrade testing to the test workflow and fixed upgrades from 1.1.0
+  to 1.2.0, from 1.3.0 to 1.3.1, and from 1.3.1 to 1.3.2.
 
 1.3.3 2024-04-08T13:44:11Z
 --------------------------
@@ -148,6 +150,17 @@ Revision history for pgTAP
   serially (#279).
 * Fixed an issue where tests might not run in parallel even when the server
   supported it (#279).
+* Added function type testing functions to complement `is_aggregate()` and
+  `isnt_aggregate()`:
+    + `is_normal_function()`
+    + `isnt_normal_function()`
+    + `is_window()`
+    + `isnt_window()`
+    + `is_procedure()`
+    + `isnt_procedure()`
+* Made the diagnostic output of `is_aggregate()` and `isnt_aggregate()`
+  consistent. Previously, when the function did not exist, some instances would
+  generate diagnostic output and some would not.
 
 1.1.0 2019-11-25T19:05:38Z
 --------------------------
@@ -259,17 +272,6 @@ Revision history for pgTAP
 * Added the materialized view-testing assertion functions to the v0.95.0 upgrade
   script; they were inadvertently omitted in the v0.95.0 release.
 * Fixed failing tests on Postgres 8.1.
-* Added function type testing functions to complement `is_aggregate()` and
-  `isnt_aggregate()`:
-    + `is_normal_function()`
-    + `isnt_normal_function()`
-    + `is_window()`
-    + `isnt_window()`
-    + `is_procedure()`
-    + `isnt_procedure()`
-* Made the diagnostic output of `is_aggregate()` and `isnt_aggregate()`
-  consistent. Previously, when the function did not exist, some instances would
-  generate diagnostic output and some would not.
 
 0.97.0 2016-11-28T22:18:29Z
 ---------------------------

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for pgTAP
 ==========================
 
-1.3.4
+1.3.4 2025-10-04T17:20:28Z
 --------------------------
 
 * Fixed the upgrade from v1.2.0 to v1.3.0. Thanks to @runqitian for the pull

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ endif
 EXTRA_CLEAN += sql/pgtap--0.99.0--1.0.0.sql
 sql/pgtap--0.99.0--1.0.0.sql: sql/pgtap--0.99.0--1.0.0.sql.in
 	cp $< $@
-ifeq ($(shell echo $(VERSION) | grep -qE "^9[.][01234]|" && echo yes || echo no),yes)
+ifeq ($(shell echo $(VERSION) | grep -qE "^9[.][01234]" && echo yes || echo no),yes)
 	patch -p0 < compat/9.4/pgtap--0.99.0--1.0.0.patch
 endif
 

--- a/compat/install-9.1.patch
+++ b/compat/install-9.1.patch
@@ -11,7 +11,7 @@
      RETURN ok( FALSE, descr ) || E'\n' || diag(
             '    died: ' || _error_diag(SQLSTATE, SQLERRM, detail, hint, context, schname, tabname, colname, chkname, typname)
      );
-@@ -6732,10 +6728,6 @@
+@@ -6787,10 +6783,6 @@
                  -- Something went wrong. Record that fact.
                  errstate := SQLSTATE;
                  errmsg := SQLERRM;
@@ -22,7 +22,7 @@
              END;
  
              -- Always raise an exception to rollback any changes.
-@@ -7203,7 +7195,6 @@
+@@ -7258,7 +7250,6 @@
      RETURN ok( true, $3 );
  EXCEPTION
      WHEN datatype_mismatch THEN
@@ -30,7 +30,7 @@
          RETURN ok( false, $3 ) || E'\n' || diag(
              E'    Number of columns or their types differ between the queries' ||
              CASE WHEN have_rec::TEXT = want_rec::text THEN '' ELSE E':\n' ||
-@@ -7357,7 +7348,6 @@
+@@ -7412,7 +7403,6 @@
      RETURN ok( false, $3 );
  EXCEPTION
      WHEN datatype_mismatch THEN

--- a/compat/install-9.2.patch
+++ b/compat/install-9.2.patch
@@ -14,7 +14,7 @@
      RETURN ok( FALSE, descr ) || E'\n' || diag(
             '    died: ' || _error_diag(SQLSTATE, SQLERRM, detail, hint, context, schname, tabname, colname, chkname, typname)
      );
-@@ -6740,12 +6735,7 @@
+@@ -6795,12 +6790,7 @@
                  GET STACKED DIAGNOSTICS
                      detail  = PG_EXCEPTION_DETAIL,
                      hint    = PG_EXCEPTION_HINT,

--- a/compat/install-9.4.patch
+++ b/compat/install-9.4.patch
@@ -18,7 +18,7 @@
      -- There should have been no exception.
      GET STACKED DIAGNOSTICS
          detail  = PG_EXCEPTION_DETAIL,
-@@ -10284,233 +10284,6 @@
+@@ -10339,233 +10339,6 @@
      ), $2);
  $$ LANGUAGE SQL immutable;
  

--- a/compat/install-9.6.patch
+++ b/compat/install-9.6.patch
@@ -1,6 +1,6 @@
 --- sql/pgtap.sql
 +++ sql/pgtap.sql
-@@ -10266,136 +10266,6 @@
+@@ -10321,136 +10321,6 @@
      );
  $$ LANGUAGE sql;
  

--- a/contrib/pgtap.spec
+++ b/contrib/pgtap.spec
@@ -41,8 +41,11 @@ make install USE_PGXS=1 DESTDIR=%{buildroot}
 %{_docdir}/pgsql/contrib/README.pgtap
 
 %changelog
-* Mon Apr 8 2024 David E. Wheeler <david@justatheory.com> 1.3.4-1
+* Mon Oct 4 2025 David E. Wheeler <david@justatheory.com> 1.3.4-1
 - Update to 1.3.4
+
+* Mon Apr 8 2024 David E. Wheeler <david@justatheory.com> 1.3.3-1
+- Update to 1.3.3
 
 * Sun Feb 4 2024 David E. Wheeler <david@justatheory.com> 1.3.2-1
 - Update to 1.3.2

--- a/release.md
+++ b/release.md
@@ -47,7 +47,7 @@ Here are the steps to take to make a release of pgTAP:
     installed), then checkout the `gh-pages` branch and make these changes:
 
     +   `cp .documentation.html.template documentation.html`. Edit
-        documentation.html, the main div should look like this:
+        `documentation.html`, the main div should look like this:
 
             <div id="main">
               <!-- DOCS INTRO HERE -->

--- a/sql/pgtap--1.1.0--1.2.0.sql
+++ b/sql/pgtap--1.1.0--1.2.0.sql
@@ -329,6 +329,26 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
+DROP VIEW IF EXISTS tap_funky;
+CREATE VIEW tap_funky
+ AS SELECT p.oid         AS oid,
+           n.nspname     AS schema,
+           p.proname     AS name,
+           pg_catalog.pg_get_userbyid(p.proowner) AS owner,
+           array_to_string(p.proargtypes::regtype[], ',') AS args,
+           CASE p.proretset WHEN TRUE THEN 'setof ' ELSE '' END
+             || p.prorettype::regtype AS returns,
+           p.prolang     AS langoid,
+           p.proisstrict AS is_strict,
+           _prokind(p.oid) AS kind,
+           p.prosecdef   AS is_definer,
+           p.proretset   AS returns_set,
+           p.provolatile::char AS volatility,
+           pg_catalog.pg_function_is_visible(p.oid) AS is_visible
+      FROM pg_catalog.pg_proc p
+      JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
+;
+
 -- Returns true if the specified function exists and is the specified type,
 -- false if it exists and is not the specified type, and NULL if it does not
 -- exist. Types are f for a normal function, p for a procedure, a for an

--- a/sql/pgtap--1.3.0--1.3.1.sql
+++ b/sql/pgtap--1.3.0--1.3.1.sql
@@ -1,7 +1,17 @@
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS 'pgtap'
-LANGUAGE C STABLE STRICT;
+-- Use DO to ignore failures when the shared library doesn't exist, because it
+-- only existed for 1.3.1, and if upgrades are running from a later release it
+-- won't be there.
+DO $$
+BEGIN
+    CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
+    RETURNS RECORD
+    AS 'pgtap'
+    LANGUAGE C STABLE STRICT;
+EXCEPTION
+    WHEN undefined_file THEN
+        RAISE NOTICE 'No pgtap shared library; skipping C parse_type()';
+END;
+$$;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
@@ -211,3 +221,9 @@ END;
 $$ LANGUAGE plpgsql;
 
 DROP FUNCTION _quote_ident_like(TEXT, TEXT);
+
+-- has_pk( schema, table )
+CREATE OR REPLACE FUNCTION has_pk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_pk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a primary key' );
+$$ LANGUAGE sql;

--- a/sql/pgtap--1.3.1--1.3.2.sql
+++ b/sql/pgtap--1.3.1--1.3.2.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4);
+DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$


### PR DESCRIPTION
Fix upgrades from 1.1.0 to 1.2.0, from 1.3.0 to 1.3.1, and from 1.3.1 to 1.3.2. Restore upgrade testing to the test workflow.

Also move change items accidentally added to 0.98.0 to 1.2.0 when they were actually added, and update patch offsets.