### PR TITLE
Fix minor doc formatting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ uninstall_pgtap.sql
 results
 regression.*
 *.html
-*.html1
 *.sql.orig
 bbin
 

--- a/Makefile
+++ b/Makefile
@@ -287,11 +287,23 @@ $(B_DIR)/static/%/: %/ $(B_DIR)/static
 # Make sure that we build the regression tests.
 installcheck: test/setup.sql
 
-html:
+doc/pgtap.html: doc/pgtap.md
 	multimarkdown doc/pgtap.md > doc/pgtap.html
-# 	discount -f FENCEDCODE -f DLEXTRA -f HTML5 -f TOC -f FOOTNOTE -f IDANCHOR doc/pgtap.md > doc/pgtap.html
-	tools/tocgen doc/pgtap.html 2> doc/toc.html
+
+# We use multimarkdown to preserve link IDs on pgtap.org, but keep a reference
+# to the discount version as it's preferable in some ways, so we may want to
+# change it in the future.
+# Flags reference: https://github.com/Orc/discount/blob/main/flags.c
+doc/pgtap-discount.html: doc/pgtap.md
+	discount -f FENCEDCODE -f DLEXTRA -f HTML5 -f TOC -f FOOTNOTE -f IDANCHOR -f TOC $< > $@
+
+doc/toc.html: doc/pgtap.html
+	tools/tocgen $< 2> $@
+
+doc/pg_prove.html:
 	perl -MPod::Simple::XHTML -E "my \$$p = Pod::Simple::XHTML->new; \$$p->html_header_tags('<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">'); \$$p->strip_verbatim_indent(sub { my \$$l = shift; (my \$$i = \$$l->[0]) =~ s/\\S.*//; \$$i }); \$$p->parse_from_file('`perldoc -l pg_prove`')" > doc/pg_prove.html
+
+html: doc/pgtap.html doc/toc.html doc/pg_prove.html
 
 #
 # Actual test targets

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -77,7 +77,7 @@ make install
 make installcheck
 ```
 
-tial Issues
+Potential Issues
 ----------------
 
 If you encounter an error such as:
@@ -729,7 +729,7 @@ Its advantages over `ok()` are similar to that of `is()` and `isnt()`: Better
 diagnostics on failure.
 
 ### `unalike()` ###
-### `unalike()` ###
+### `unialike()` ###
 
 ```sql
 SELECT unalike(  :this, :like, :description );
@@ -1371,27 +1371,27 @@ For example, say that you want to compare queries against a `persons` table.
 The simplest way to sort is by `name`, as in:
 
 ```pgsql
- try=# select * from people order by name;
-   name  | age
- --------+-----
-  Damian |  19
-  Larry  |  53
-  Tom    |  44
-  Tom    |  35
- (4 rows)
+try=# select * from people order by name;
+  name  | age
+--------+-----
+ Damian |  19
+ Larry  |  53
+ Tom    |  44
+ Tom    |  35
+(4 rows)
 ```
 
 But a different run of the same query could have the rows in different order:
 
 ```pgsql
- try=# select * from people order by name;
-   name  | age
- --------+-----
-  Damian |  19
-  Larry  |  53
-  Tom    |  35
-  Tom    |  44
- (4 rows)
+try=# select * from people order by name;
+  name  | age
+--------+-----
+ Damian |  19
+ Larry  |  53
+ Tom    |  35
+ Tom    |  44
+(4 rows)
  ```
 
 Notice how the two "Tom" rows are reversed. The upshot is that you must ensure
@@ -6906,7 +6906,7 @@ Tests that a database user is a super user. If the description is omitted, it
 will default to "User `:user` should be a super user". Example:
 
 ```sql
-    SELECT is_superuser('theory');
+SELECT is_superuser('theory');
 ```
 
 If the user does not exist in the database, the diagnostics will say so.
@@ -6956,11 +6956,6 @@ SELECT is_member_of( :role, :member );
 `:description`
 : A short description of the test.
 
-```sql
-SELECT is_member_of( 'sweeties', 'anna' 'Anna should be a sweetie' );
-SELECT is_member_of( 'meanies', ARRAY['dr_evil', 'dr_no' ] );
-```
-
 Checks whether a group role contains a member role or all of an array of
 member roles. If the description is omitted, it will default to "Should have
 members of role `:role`." On failure, `is_member_of()` will output
@@ -6974,6 +6969,13 @@ diagnostics listing the missing member roles, like so:
 If the group role does not exist, the diagnostics will tell you that, instead.
 But you use `has_role()` to make sure the role exists before you check its
 members, don't you? Of course you do.
+
+Exmples:
+
+```sql
+SELECT is_member_of( 'sweeties', 'anna' 'Anna should be a sweetie' );
+SELECT is_member_of( 'meanies', ARRAY['dr_evil', 'dr_no' ] );
+```
 
 ### `isnt_member_of()` ###
 

--- a/tools/tocgen
+++ b/tools/tocgen
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 use English;
-$INPLACE_EDIT=1;
+$INPLACE_EDIT='';
 
 
 our $prevn;


### PR DESCRIPTION
Fix a couple of documentation formatting issues and move the `is_member_of()` examples below the description. Also update the `html` target in the `Makefile` to use proper targets for each of the files it generates, and eliminate the generation of the `doc/pgtap.html1` backup file by `tools/tocgen`.