### PR TITLE
Improved col_is{nt}_X implementation

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,13 @@ Revision history for pgTAP
   and `hasnt_check()`. Also changed `has_unique()` argument types from `TEXT`
   to `NAME` so they can share a consistent overload order with the other
   constraint assertions. Thanks to @RampantDespair for the PR (#370).
+* Added missing `schema, table, columns[]` and `schema, table, column` variants
+  of `col_isnt_pk()`, `col_is_fk()`, and `col_isnt_fk()`, and established a
+  consistent overload order for `col_is_pk()`, `col_isnt_pk()`, `col_is_fk()`,
+  `col_isnt_fk()`, and `col_is_unique()`. Added `col_isnt_unique()` with the
+  same consistent overload order. Standardized SQL function comments to use
+  plural `columns[]` for array arguments. Thanks to @RampantDespair for the PR
+  (#369).
 
 1.3.4 2025-10-04T17:20:28Z
 --------------------------

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -5231,6 +5231,14 @@ SELECT col_is_pk( 'myschema', 'sometable', 'id' );
 SELECT col_is_pk( 'persons',  ARRAY['given_name', 'surname'] );
 ```
 
+For a 3-argument schema-qualified call without a description, use `NAME` or
+`NAME[]` casts to distinguish it from the 3-argument
+`(table, column(s), description)` overload. For example:
+
+```sql
+SELECT col_is_pk( 'myschema', 'sometable'::name, 'pk_name'::name );
+```
+
 If the schema is omitted, the table must be visible in the search path. If the
 test description is omitted, it will be set to "Column `:table(:column)`
 should be a primary key". Note that this test will fail if the table or column
@@ -5253,6 +5261,8 @@ Will produce something like this:
 ```sql
 SELECT col_isnt_pk( :schema, :table, :columns, :description );
 SELECT col_isnt_pk( :schema, :table, :column, :description );
+SELECT col_isnt_pk( :schema, :table, :columns );
+SELECT col_isnt_pk( :schema, :table, :column );
 SELECT col_isnt_pk( :table, :columns, :description );
 SELECT col_isnt_pk( :table, :column, :description );
 SELECT col_isnt_pk( :table, :columns );
@@ -5279,11 +5289,21 @@ SELECT col_isnt_pk( :table, :column );
 This function is the inverse of `col_is_pk()`. The test passes if the
 specified column or columns are not a primary key.
 
+For a 3-argument schema-qualified call without a description, use `NAME` or
+`NAME[]` casts to distinguish it from the 3-argument
+`(table, column(s), description)` overload. For example:
+
+```sql
+SELECT col_isnt_pk( 'myschema', 'sometable'::name, 'pk_name'::name );
+```
+
 ### `col_is_fk()` ###
 
 ```sql
 SELECT col_is_fk( :schema, :table, :columns, :description );
 SELECT col_is_fk( :schema, :table, :column, :description );
+SELECT col_is_fk( :schema, :table, :columns );
+SELECT col_is_fk( :schema, :table, :column );
 SELECT col_is_fk( :table, :columns, :description );
 SELECT col_is_fk( :table, :column, :description );
 SELECT col_is_fk( :table, :columns );
@@ -5316,11 +5336,21 @@ simply list all of the foreign key constraint columns, like so:
     #        {thingy_id}
     #        {surname,given_name}
 
+For a 3-argument schema-qualified call without a description, use `NAME` or
+`NAME[]` casts to distinguish it from the 3-argument
+`(table, column(s), description)` overload. For example:
+
+```sql
+SELECT col_is_fk( 'myschema', 'sometable'::name, 'fk_name'::name );
+```
+
 ### `col_isnt_fk()` ###
 
 ```sql
 SELECT col_isnt_fk( :schema, :table, :columns, :description );
 SELECT col_isnt_fk( :schema, :table, :column, :description );
+SELECT col_isnt_fk( :schema, :table, :columns );
+SELECT col_isnt_fk( :schema, :table, :column );
 SELECT col_isnt_fk( :table, :columns, :description );
 SELECT col_isnt_fk( :table, :column, :description );
 SELECT col_isnt_fk( :table, :columns );
@@ -5346,6 +5376,14 @@ SELECT col_isnt_fk( :table, :column );
 
 This function is the inverse of `col_is_fk()`. The test passes if the
 specified column or columns are not a foreign key.
+
+For a 3-argument schema-qualified call without a description, use `NAME` or
+`NAME[]` casts to distinguish it from the 3-argument
+`(table, column(s), description)` overload. For example:
+
+```sql
+SELECT col_isnt_fk( 'myschema', 'sometable'::name, 'fk_name'::name );
+```
 
 ### `fk_ok()` ###
 
@@ -5531,9 +5569,9 @@ SELECT col_is_unique(
 );
 ```
 
-If you omit the description for the 3-argument version, you'll need to cast
-the table and column parameters to the `NAME` data type so that PostgreSQL
-doesn't resolve the function name as a description. For example:
+For a 3-argument schema-qualified call without a description, use `NAME` or
+`NAME[]` casts to distinguish it from the 3-argument
+`(table, column(s), description)` overload. For example:
 
 ```sql
 SELECT col_is_unique( 'myschema', 'sometable'::name, 'other_id'::name );
@@ -5546,6 +5584,47 @@ were actually found, if any:
             have: {username}
                   {first_name,last_name}
             want: {email}
+
+### `col_isnt_unique()` ###
+
+```sql
+SELECT col_isnt_unique( schema, table, columns, description );
+SELECT col_isnt_unique( schema, table, column, description );
+SELECT col_isnt_unique( schema, table, columns );
+SELECT col_isnt_unique( schema, table, column );
+SELECT col_isnt_unique( table, columns, description );
+SELECT col_isnt_unique( table, column, description );
+SELECT col_isnt_unique( table, columns );
+SELECT col_isnt_unique( table, column );
+```
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the table.
+
+`:table`
+: Name of a table not containing the unique constraint.
+
+`:columns`
+: Array of the names of the columns that should not have a unique constraint.
+
+`:column`
+: Name of the column that should not have a unique constraint.
+
+`:description`
+: A short description of the test.
+
+This function is the inverse of `col_is_unique()`. The test passes if the
+specified column or columns do not have a unique constraint.
+
+For a 3-argument schema-qualified call without a description, use `NAME` or
+`NAME[]` casts to distinguish it from the 3-argument
+`(table, column(s), description)` overload. For example:
+
+```sql
+SELECT col_isnt_unique( 'myschema', 'sometable'::name, 'other_id'::name );
+```
 
 ### `has_check()` ###
 

--- a/sql/pgtap--0.92.0--0.93.0.sql
+++ b/sql/pgtap--0.92.0--0.93.0.sql
@@ -84,7 +84,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- fk_ok( fk_table, fk_column[], pk_table, pk_column[], description )
+-- fk_ok( fk_table, fk_columns[], pk_table, pk_columns[], description )
 CREATE OR REPLACE FUNCTION fk_ok ( NAME, NAME[], NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
 DECLARE

--- a/sql/pgtap--0.94.0--0.95.0.sql
+++ b/sql/pgtap--0.94.0--0.95.0.sql
@@ -384,7 +384,7 @@ RETURNS TEXT AS $$
     SELECT ok( NOT _strict($1), 'Function ' || quote_ident($1) || '() should not be strict' );
 $$ LANGUAGE sql;
 
--- col_is_unique( schema, table, column[] )
+-- col_is_unique( schema, table, columns[] )
 CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, NAME[] )
 RETURNS TEXT AS $$
     SELECT col_is_unique( $1, $2, $3, 'Columns ' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should have a unique constraint' );

--- a/sql/pgtap--1.2.0--1.3.0.sql
+++ b/sql/pgtap--1.2.0--1.3.0.sql
@@ -144,7 +144,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- col_is_pk( schema, table, column[] )
+-- col_is_pk( schema, table, columns[] )
 CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME, NAME[] )
 RETURNS TEXT AS $$
     SELECT col_is_pk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should be a primary key' );

--- a/sql/pgtap--1.3.4--1.3.5.sql
+++ b/sql/pgtap--1.3.4--1.3.5.sql
@@ -100,3 +100,101 @@ CREATE OR REPLACE FUNCTION hasnt_check ( NAME )
 RETURNS TEXT AS $$
     SELECT hasnt_check( $1, 'Table ' || quote_ident($1) || ' should not have a check constraint' );
 $$ LANGUAGE sql;
+
+-- col_isnt_pk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_pk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should not be a primary key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_pk( schema, table, column )
+CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_pk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should not be a primary key' );
+$$ LANGUAGE sql;
+
+-- col_is_fk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_fk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_is_fk( schema, table, column )
+CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_is_fk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_fk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_fk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should not be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_fk( schema, table, column )
+CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_fk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should not be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, columns[], description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+              FROM _keys($1, $2, 'u') AS keys(key_columns)
+             WHERE key_columns = $3
+        ),
+        $4
+    );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, column, description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, ARRAY[$3], $4 );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, $3, 'Columns ' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, column )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, ARRAY[$3], 'Column ' || quote_ident($2) || '(' || quote_ident($3) || ') should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, columns[], description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+              FROM _keys($1, 'u') AS keys(key_columns)
+             WHERE key_columns = $2
+        ),
+        $3
+    );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, column, description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, ARRAY[$2], $3 );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, column )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, 'Column ' || quote_ident($1) || '(' || quote_ident($2) || ') should not have a unique constraint' );
+$$ LANGUAGE sql;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -2056,28 +2056,10 @@ RETURNS NAME[] AS $$
     SELECT * FROM _keys($1, $2) LIMIT 1;
 $$ LANGUAGE sql;
 
--- col_is_pk( schema, table, column[], description )
+-- col_is_pk( schema, table, columns[], description )
 CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT is( _ckeys( $1, $2, 'p' ), $3, $4 );
-$$ LANGUAGE sql;
-
--- col_is_pk( schema, table, column[] )
-CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_is_pk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should be a primary key' );
-$$ LANGUAGE sql;
-
--- col_is_pk( table, column[], description )
-CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME[], TEXT )
-RETURNS TEXT AS $$
-    SELECT is( _ckeys( $1, 'p' ), $2, $3 );
-$$ LANGUAGE sql;
-
--- col_is_pk( table, column[] )
-CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_is_pk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should be a primary key' );
 $$ LANGUAGE sql;
 
 -- col_is_pk( schema, table, column, description )
@@ -2086,10 +2068,22 @@ RETURNS TEXT AS $$
     SELECT col_is_pk( $1, $2, ARRAY[$3], $4 );
 $$ LANGUAGE sql;
 
+-- col_is_pk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_pk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should be a primary key' );
+$$ LANGUAGE sql;
+
 -- col_is_pk( schema, table, column )
 CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME, NAME )
 RETURNS TEXT AS $$
     SELECT col_is_pk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should be a primary key' );
+$$ LANGUAGE sql;
+
+-- col_is_pk( table, columns[], description )
+CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT is( _ckeys( $1, 'p' ), $2, $3 );
 $$ LANGUAGE sql;
 
 -- col_is_pk( table, column, description )
@@ -2098,28 +2092,22 @@ RETURNS TEXT AS $$
     SELECT col_is_pk( $1, ARRAY[$2], $3 );
 $$ LANGUAGE sql;
 
+-- col_is_pk( table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_pk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should be a primary key' );
+$$ LANGUAGE sql;
+
 -- col_is_pk( table, column )
 CREATE OR REPLACE FUNCTION col_is_pk ( NAME, NAME )
 RETURNS TEXT AS $$
     SELECT col_is_pk( $1, $2, 'Column ' || quote_ident($1) || '(' || quote_ident($2) || ') should be a primary key' );
 $$ LANGUAGE sql;
 
--- col_isnt_pk( schema, table, column, description )
+-- col_isnt_pk( schema, table, columns[], description )
 CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT isnt( _ckeys( $1, $2, 'p' ), $3, $4 );
-$$ LANGUAGE sql;
-
--- col_isnt_pk( table, column, description )
-CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME[], TEXT )
-RETURNS TEXT AS $$
-    SELECT isnt( _ckeys( $1, 'p' ), $2, $3 );
-$$ LANGUAGE sql;
-
--- col_isnt_pk( table, column[] )
-CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_isnt_pk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should not be a primary key' );
 $$ LANGUAGE sql;
 
 -- col_isnt_pk( schema, table, column, description )
@@ -2128,10 +2116,34 @@ RETURNS TEXT AS $$
     SELECT col_isnt_pk( $1, $2, ARRAY[$3], $4 );
 $$ LANGUAGE sql;
 
+-- col_isnt_pk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_pk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should not be a primary key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_pk( schema, table, column )
+CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_pk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should not be a primary key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_pk( table, columns[], description )
+CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT isnt( _ckeys( $1, 'p' ), $2, $3 );
+$$ LANGUAGE sql;
+
 -- col_isnt_pk( table, column, description )
 CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT col_isnt_pk( $1, ARRAY[$2], $3 );
+$$ LANGUAGE sql;
+
+-- col_isnt_pk( table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_pk ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_pk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should not be a primary key' );
 $$ LANGUAGE sql;
 
 -- col_isnt_pk( table, column )
@@ -2210,7 +2222,7 @@ RETURNS BOOLEAN AS $$
     );
 $$ LANGUAGE SQL;
 
--- col_is_fk( schema, table, column, description )
+-- col_is_fk( schema, table, columns[], description )
 CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
 DECLARE
@@ -2243,7 +2255,25 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- col_is_fk( table, column, description )
+-- col_is_fk( schema, table, column, description )
+CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT col_is_fk( $1, $2, ARRAY[$3], $4 );
+$$ LANGUAGE sql;
+
+-- col_is_fk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_fk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_is_fk( schema, table, column )
+CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_is_fk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_is_fk( table, columns[], description )
 CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
 DECLARE
@@ -2275,22 +2305,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- col_is_fk( table, column[] )
-CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_is_fk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should be a foreign key' );
-$$ LANGUAGE sql;
-
--- col_is_fk( schema, table, column, description )
-CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, NAME, TEXT )
-RETURNS TEXT AS $$
-    SELECT col_is_fk( $1, $2, ARRAY[$3], $4 );
-$$ LANGUAGE sql;
-
 -- col_is_fk( table, column, description )
 CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT col_is_fk( $1, ARRAY[$2], $3 );
+$$ LANGUAGE sql;
+
+-- col_is_fk( table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_fk ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_fk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should be a foreign key' );
 $$ LANGUAGE sql;
 
 -- col_is_fk( table, column )
@@ -2299,23 +2323,11 @@ RETURNS TEXT AS $$
     SELECT col_is_fk( $1, $2, 'Column ' || quote_ident($1) || '(' || quote_ident($2) || ') should be a foreign key' );
 $$ LANGUAGE sql;
 
--- col_isnt_fk( schema, table, column, description )
+-- col_isnt_fk( schema, table, columns[], description )
 CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT ok( NOT _fkexists( $1, $2, $3 ), $4 );
 $$ LANGUAGE SQL;
-
--- col_isnt_fk( table, column, description )
-CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME[], TEXT )
-RETURNS TEXT AS $$
-    SELECT ok( NOT _fkexists( $1, $2 ), $3 );
-$$ LANGUAGE SQL;
-
--- col_isnt_fk( table, column[] )
-CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_isnt_fk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should not be a foreign key' );
-$$ LANGUAGE sql;
 
 -- col_isnt_fk( schema, table, column, description )
 CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, NAME, TEXT )
@@ -2323,10 +2335,34 @@ RETURNS TEXT AS $$
     SELECT col_isnt_fk( $1, $2, ARRAY[$3], $4 );
 $$ LANGUAGE sql;
 
+-- col_isnt_fk( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_fk( $1, $2, $3, 'Columns ' || quote_ident($1) || '.' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should not be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_fk( schema, table, column )
+CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_fk( $1, $2, $3, 'Column ' || quote_ident($1) || '.' || quote_ident($2) || '(' || quote_ident($3) || ') should not be a foreign key' );
+$$ LANGUAGE sql;
+
+-- col_isnt_fk( table, columns[], description )
+CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _fkexists( $1, $2 ), $3 );
+$$ LANGUAGE SQL;
+
 -- col_isnt_fk( table, column, description )
 CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT col_isnt_fk( $1, ARRAY[$2], $3 );
+$$ LANGUAGE sql;
+
+-- col_isnt_fk( table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_fk ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_fk( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should not be a foreign key' );
 $$ LANGUAGE sql;
 
 -- col_isnt_fk( table, column )
@@ -2431,34 +2467,10 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- col_is_unique( schema, table, column, description )
+-- col_is_unique( schema, table, columns[], description )
 CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
     SELECT _constraint( $1, $2, 'u', $3, $4, 'unique' );
-$$ LANGUAGE sql;
-
--- col_is_unique( schema, table, column[] )
-CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_is_unique( $1, $2, $3, 'Columns ' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should have a unique constraint' );
-$$ LANGUAGE sql;
-
--- col_is_unique( scheam, table, column )
-CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, NAME )
-RETURNS TEXT AS $$
-    SELECT col_is_unique( $1, $2, ARRAY[$3], 'Column ' || quote_ident($2) || '(' || quote_ident($3) || ') should have a unique constraint' );
-$$ LANGUAGE sql;
-
--- col_is_unique( table, column, description )
-CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME[], TEXT )
-RETURNS TEXT AS $$
-    SELECT _constraint( $1, 'u', $2, $3, 'unique' );
-$$ LANGUAGE sql;
-
--- col_is_unique( table, column[] )
-CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME[] )
-RETURNS TEXT AS $$
-    SELECT col_is_unique( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should have a unique constraint' );
 $$ LANGUAGE sql;
 
 -- col_is_unique( schema, table, column, description )
@@ -2467,16 +2479,102 @@ RETURNS TEXT AS $$
     SELECT col_is_unique( $1, $2, ARRAY[$3], $4 );
 $$ LANGUAGE sql;
 
+-- col_is_unique( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_unique( $1, $2, $3, 'Columns ' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_is_unique( schema, table, column )
+CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_is_unique( $1, $2, ARRAY[$3], 'Column ' || quote_ident($2) || '(' || quote_ident($3) || ') should have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_is_unique( table, columns[], description )
+CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT _constraint( $1, 'u', $2, $3, 'unique' );
+$$ LANGUAGE sql;
+
 -- col_is_unique( table, column, description )
 CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT col_is_unique( $1, ARRAY[$2], $3 );
 $$ LANGUAGE sql;
 
+-- col_is_unique( table, columns[] )
+CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_is_unique( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should have a unique constraint' );
+$$ LANGUAGE sql;
+
 -- col_is_unique( table, column )
 CREATE OR REPLACE FUNCTION col_is_unique ( NAME, NAME )
 RETURNS TEXT AS $$
     SELECT col_is_unique( $1, $2, 'Column ' || quote_ident($1) || '(' || quote_ident($2) || ') should have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, columns[], description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+              FROM _keys($1, $2, 'u') AS keys(key_columns)
+             WHERE key_columns = $3
+        ),
+        $4
+    );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, column, description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, ARRAY[$3], $4 );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, $3, 'Columns ' || quote_ident($2) || '(' || _ident_array_to_string($3, ', ') || ') should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( schema, table, column )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, ARRAY[$3], 'Column ' || quote_ident($2) || '(' || quote_ident($3) || ') should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, columns[], description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+    SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+              FROM _keys($1, 'u') AS keys(key_columns)
+             WHERE key_columns = $2
+        ),
+        $3
+    );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, column, description )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, ARRAY[$2], $3 );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, columns[] )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- col_isnt_unique( table, column )
+CREATE OR REPLACE FUNCTION col_isnt_unique ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT col_isnt_unique( $1, $2, 'Column ' || quote_ident($1) || '(' || quote_ident($2) || ') should not have a unique constraint' );
 $$ LANGUAGE sql;
 
 -- has_check( schema, table, description )
@@ -2539,7 +2637,7 @@ RETURNS TEXT AS $$
     SELECT _constraint( $1, 'c', $2, $3, 'check' );
 $$ LANGUAGE sql;
 
--- col_has_check( table, column[] )
+-- col_has_check( table, columns[] )
 CREATE OR REPLACE FUNCTION col_has_check ( NAME, NAME[] )
 RETURNS TEXT AS $$
     SELECT col_has_check( $1, $2, 'Columns ' || quote_ident($1) || '(' || _ident_array_to_string($2, ', ') || ') should have a check constraint' );
@@ -2563,7 +2661,7 @@ RETURNS TEXT AS $$
     SELECT col_has_check( $1, $2, 'Column ' || quote_ident($1) || '(' || quote_ident($2) || ') should have a check constraint' );
 $$ LANGUAGE sql;
 
--- fk_ok( fk_schema, fk_table, fk_column[], pk_schema, pk_table, pk_column[], description )
+-- fk_ok( fk_schema, fk_table, fk_columns[], pk_schema, pk_table, pk_columns[], description )
 CREATE OR REPLACE FUNCTION fk_ok ( NAME, NAME, NAME[], NAME, NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
 DECLARE
@@ -2591,7 +2689,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- fk_ok( fk_table, fk_column[], pk_table, pk_column[], description )
+-- fk_ok( fk_table, fk_columns[], pk_table, pk_columns[], description )
 CREATE OR REPLACE FUNCTION fk_ok ( NAME, NAME[], NAME, NAME[], TEXT )
 RETURNS TEXT AS $$
 DECLARE
@@ -2618,7 +2716,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- fk_ok( fk_schema, fk_table, fk_column[], fk_schema, pk_table, pk_column[] )
+-- fk_ok( fk_schema, fk_table, fk_columns[], fk_schema, pk_table, pk_columns[] )
 CREATE OR REPLACE FUNCTION fk_ok ( NAME, NAME, NAME[], NAME, NAME, NAME[] )
 RETURNS TEXT AS $$
     SELECT fk_ok( $1, $2, $3, $4, $5, $6,
@@ -2628,7 +2726,7 @@ RETURNS TEXT AS $$
     );
 $$ LANGUAGE sql;
 
--- fk_ok( fk_table, fk_column[], pk_table, pk_column[] )
+-- fk_ok( fk_table, fk_columns[], pk_table, pk_columns[] )
 CREATE OR REPLACE FUNCTION fk_ok ( NAME, NAME[], NAME, NAME[] )
 RETURNS TEXT AS $$
     SELECT fk_ok( $1, $2, $3, $4,

--- a/test/expected/fktap.out
+++ b/test/expected/fktap.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..140
+1..149
 ok 1 - has_fk( schema, table, description ) should pass
 ok 2 - has_fk( schema, table, description ) should have the proper description
 ok 3 - has_fk( schema, table ) should pass
@@ -32,111 +32,120 @@ ok 29 - hasnt_fk( table, description ) pass should pass
 ok 30 - hasnt_fk( table, description ) pass should have the proper description
 ok 31 - col_is_fk( schema, table, column, description ) should pass
 ok 32 - col_is_fk( schema, table, column, description ) should have the proper description
-ok 33 - col_is_fk( table, column, description ) should pass
-ok 34 - col_is_fk( table, column, description ) should have the proper description
-ok 35 - col_is_fk( table, column ) should pass
-ok 36 - col_is_fk( table, column ) should have the proper description
-ok 37 - col_is_fk( schema, table, column, description ) should fail
-ok 38 - col_is_fk( schema, table, column, description ) should have the proper description
-ok 39 - col_is_fk( schema, table, column, description ) should have the proper diagnostics
-ok 40 - col_is_fk( table, column, description ) should fail
-ok 41 - col_is_fk( table, column, description ) should have the proper description
-ok 42 - col_is_fk( table, column, description ) should have the proper diagnostics
-ok 43 - multi-fk col_is_fk test should pass
-ok 44 - multi-fk col_is_fk test should have the proper description
-ok 45 - col_is_fk with no FKs should fail
-ok 46 - col_is_fk with no FKs should have the proper description
-ok 47 - col_is_fk with no FKs should have the proper diagnostics
-ok 48 - col_is_fk with no FKs should fail
-ok 49 - col_is_fk with no FKs should have the proper description
-ok 50 - col_is_fk with no FKs should have the proper diagnostics
-ok 51 - col_is_fk( schema, table, column[], description ) should pass
-ok 52 - col_is_fk( schema, table, column[], description ) should have the proper description
-ok 53 - col_is_fk( table, column[], description ) should pass
-ok 54 - col_is_fk( table, column[], description ) should have the proper description
-ok 55 - col_is_fk( table, column[] ) should pass
-ok 56 - col_is_fk( table, column[] ) should have the proper description
-ok 57 - col_isnt_fk( schema, table, column, description ) should fail
-ok 58 - col_isnt_fk( schema, table, column, description ) should have the proper description
-ok 59 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
-ok 60 - col_isnt_fk( table, column, description ) should fail
-ok 61 - col_isnt_fk( table, column, description ) should have the proper description
-ok 62 - col_isnt_fk( table, column, description ) should have the proper diagnostics
-ok 63 - col_isnt_fk( table, column ) should fail
-ok 64 - col_isnt_fk( table, column ) should have the proper description
-ok 65 - col_isnt_fk( table, column ) should have the proper diagnostics
-ok 66 - col_isnt_fk( schema, table, column, description ) should pass
-ok 67 - col_isnt_fk( schema, table, column, description ) should have the proper description
-ok 68 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
-ok 69 - col_isnt_fk( table, column, description ) should pass
-ok 70 - col_isnt_fk( table, column, description ) should have the proper description
-ok 71 - col_isnt_fk( table, column, description ) should have the proper diagnostics
-ok 72 - multi-fk col_isnt_fk test should fail
-ok 73 - multi-fk col_isnt_fk test should have the proper description
-ok 74 - multi-fk col_isnt_fk test should have the proper diagnostics
-ok 75 - col_isnt_fk with no FKs should pass
-ok 76 - col_isnt_fk with no FKs should have the proper description
-ok 77 - col_isnt_fk with no FKs should have the proper diagnostics
-ok 78 - col_isnt_fk with no FKs should pass
-ok 79 - col_isnt_fk with no FKs should have the proper description
-ok 80 - col_isnt_fk with no FKs should have the proper diagnostics
-ok 81 - col_isnt_fk( schema, table, column[], description ) should fail
-ok 82 - col_isnt_fk( schema, table, column[], description ) should have the proper description
-ok 83 - col_isnt_fk( table, column[], description ) should fail
-ok 84 - col_isnt_fk( table, column[], description ) should have the proper description
-ok 85 - col_isnt_fk( table, column[] ) should fail
-ok 86 - col_isnt_fk( table, column[] ) should have the proper description
-ok 87 - full fk_ok array should pass
-ok 88 - full fk_ok array should have the proper description
-ok 89 - pg_my_temp_schema() should pass
-ok 90 - pg_my_temp_schema() should have the proper description
-ok 91 - multiple fk fk_ok desc should pass
-ok 92 - multiple fk fk_ok desc should have the proper description
-ok 93 - fk_ok array desc should pass
-ok 94 - fk_ok array desc should have the proper description
-ok 95 - fk_ok array noschema desc should pass
-ok 96 - fk_ok array noschema desc should have the proper description
-ok 97 - multiple fk fk_ok noschema desc should pass
-ok 98 - multiple fk fk_ok noschema desc should have the proper description
-ok 99 - fk_ok array noschema should pass
-ok 100 - fk_ok array noschema should have the proper description
-ok 101 - basic fk_ok should pass
-ok 102 - basic fk_ok should have the proper description
-ok 103 - basic fk_ok desc should pass
-ok 104 - basic fk_ok desc should have the proper description
-ok 105 - basic fk_ok noschema should pass
-ok 106 - basic fk_ok noschema should have the proper description
-ok 107 - basic fk_ok noschema desc should pass
-ok 108 - basic fk_ok noschema desc should have the proper description
-ok 109 - basic fk_ok noschema desc should have the proper diagnostics
-ok 110 - Test should pass
-ok 111 - fk_ok fail should fail
-ok 112 - fk_ok fail should have the proper description
-ok 113 - fk_ok fail should have the proper diagnostics
-ok 114 - fk_ok fail desc should fail
-ok 115 - fk_ok fail desc should have the proper description
-ok 116 - fk_ok fail desc should have the proper diagnostics
-ok 117 - fk_ok fail no schema should fail
-ok 118 - fk_ok fail no schema should have the proper description
-ok 119 - fk_ok fail no schema should have the proper diagnostics
-ok 120 - fk_ok fail no schema desc should fail
-ok 121 - fk_ok fail no schema desc should have the proper description
-ok 122 - fk_ok fail no schema desc should have the proper diagnostics
-ok 123 - fk_ok bad PK test should fail
-ok 124 - fk_ok bad PK test should have the proper description
-ok 125 - fk_ok bad PK test should have the proper diagnostics
-ok 126 - double fk schema test should pass
-ok 127 - double fk schema test should have the proper description
-ok 128 - double fk schema test should have the proper diagnostics
-ok 129 - double fk test should pass
-ok 130 - double fk test should have the proper description
-ok 131 - double fk test should have the proper diagnostics
-ok 132 - double fk and col schema test should pass
-ok 133 - double fk and col schema test should have the proper description
-ok 134 - double fk and col schema test should have the proper diagnostics
-ok 135 - missing fk test should fail
-ok 136 - missing fk test should have the proper description
-ok 137 - missing fk test should have the proper diagnostics
-ok 138 - bad FK column test should fail
-ok 139 - bad FK column test should have the proper description
-ok 140 - bad FK column test should have the proper diagnostics
+ok 33 - col_is_fk( schema, table, column ) should pass
+ok 34 - col_is_fk( schema, table, column ) should have the proper description
+ok 35 - col_is_fk( table, column, description ) should pass
+ok 36 - col_is_fk( table, column, description ) should have the proper description
+ok 37 - col_is_fk( table, column ) should pass
+ok 38 - col_is_fk( table, column ) should have the proper description
+ok 39 - col_is_fk( schema, table, column, description ) should fail
+ok 40 - col_is_fk( schema, table, column, description ) should have the proper description
+ok 41 - col_is_fk( schema, table, column, description ) should have the proper diagnostics
+ok 42 - col_is_fk( table, column, description ) should fail
+ok 43 - col_is_fk( table, column, description ) should have the proper description
+ok 44 - col_is_fk( table, column, description ) should have the proper diagnostics
+ok 45 - multi-fk col_is_fk test should pass
+ok 46 - multi-fk col_is_fk test should have the proper description
+ok 47 - col_is_fk with no FKs should fail
+ok 48 - col_is_fk with no FKs should have the proper description
+ok 49 - col_is_fk with no FKs should have the proper diagnostics
+ok 50 - col_is_fk with no FKs should fail
+ok 51 - col_is_fk with no FKs should have the proper description
+ok 52 - col_is_fk with no FKs should have the proper diagnostics
+ok 53 - col_is_fk( schema, table, columns[], description ) should pass
+ok 54 - col_is_fk( schema, table, columns[], description ) should have the proper description
+ok 55 - col_is_fk( schema, table, columns[] ) should pass
+ok 56 - col_is_fk( schema, table, columns[] ) should have the proper description
+ok 57 - col_is_fk( table, columns[], description ) should pass
+ok 58 - col_is_fk( table, columns[], description ) should have the proper description
+ok 59 - col_is_fk( table, columns[] ) should pass
+ok 60 - col_is_fk( table, columns[] ) should have the proper description
+ok 61 - col_isnt_fk( schema, table, column, description ) should fail
+ok 62 - col_isnt_fk( schema, table, column, description ) should have the proper description
+ok 63 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
+ok 64 - col_isnt_fk( schema, table, column ) should fail
+ok 65 - col_isnt_fk( schema, table, column ) should have the proper description
+ok 66 - col_isnt_fk( schema, table, column ) should have the proper diagnostics
+ok 67 - col_isnt_fk( table, column, description ) should fail
+ok 68 - col_isnt_fk( table, column, description ) should have the proper description
+ok 69 - col_isnt_fk( table, column, description ) should have the proper diagnostics
+ok 70 - col_isnt_fk( table, column ) should fail
+ok 71 - col_isnt_fk( table, column ) should have the proper description
+ok 72 - col_isnt_fk( table, column ) should have the proper diagnostics
+ok 73 - col_isnt_fk( schema, table, column, description ) should pass
+ok 74 - col_isnt_fk( schema, table, column, description ) should have the proper description
+ok 75 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
+ok 76 - col_isnt_fk( table, column, description ) should pass
+ok 77 - col_isnt_fk( table, column, description ) should have the proper description
+ok 78 - col_isnt_fk( table, column, description ) should have the proper diagnostics
+ok 79 - multi-fk col_isnt_fk test should fail
+ok 80 - multi-fk col_isnt_fk test should have the proper description
+ok 81 - multi-fk col_isnt_fk test should have the proper diagnostics
+ok 82 - col_isnt_fk with no FKs should pass
+ok 83 - col_isnt_fk with no FKs should have the proper description
+ok 84 - col_isnt_fk with no FKs should have the proper diagnostics
+ok 85 - col_isnt_fk with no FKs should pass
+ok 86 - col_isnt_fk with no FKs should have the proper description
+ok 87 - col_isnt_fk with no FKs should have the proper diagnostics
+ok 88 - col_isnt_fk( schema, table, columns[], description ) should fail
+ok 89 - col_isnt_fk( schema, table, columns[], description ) should have the proper description
+ok 90 - col_isnt_fk( schema, table, columns[] ) should fail
+ok 91 - col_isnt_fk( schema, table, columns[] ) should have the proper description
+ok 92 - col_isnt_fk( table, columns[], description ) should fail
+ok 93 - col_isnt_fk( table, columns[], description ) should have the proper description
+ok 94 - col_isnt_fk( table, columns[] ) should fail
+ok 95 - col_isnt_fk( table, columns[] ) should have the proper description
+ok 96 - full fk_ok array should pass
+ok 97 - full fk_ok array should have the proper description
+ok 98 - pg_my_temp_schema() should pass
+ok 99 - pg_my_temp_schema() should have the proper description
+ok 100 - multiple fk fk_ok desc should pass
+ok 101 - multiple fk fk_ok desc should have the proper description
+ok 102 - fk_ok array desc should pass
+ok 103 - fk_ok array desc should have the proper description
+ok 104 - fk_ok array noschema desc should pass
+ok 105 - fk_ok array noschema desc should have the proper description
+ok 106 - multiple fk fk_ok noschema desc should pass
+ok 107 - multiple fk fk_ok noschema desc should have the proper description
+ok 108 - fk_ok array noschema should pass
+ok 109 - fk_ok array noschema should have the proper description
+ok 110 - basic fk_ok should pass
+ok 111 - basic fk_ok should have the proper description
+ok 112 - basic fk_ok desc should pass
+ok 113 - basic fk_ok desc should have the proper description
+ok 114 - basic fk_ok noschema should pass
+ok 115 - basic fk_ok noschema should have the proper description
+ok 116 - basic fk_ok noschema desc should pass
+ok 117 - basic fk_ok noschema desc should have the proper description
+ok 118 - basic fk_ok noschema desc should have the proper diagnostics
+ok 119 - Test should pass
+ok 120 - fk_ok fail should fail
+ok 121 - fk_ok fail should have the proper description
+ok 122 - fk_ok fail should have the proper diagnostics
+ok 123 - fk_ok fail desc should fail
+ok 124 - fk_ok fail desc should have the proper description
+ok 125 - fk_ok fail desc should have the proper diagnostics
+ok 126 - fk_ok fail no schema should fail
+ok 127 - fk_ok fail no schema should have the proper description
+ok 128 - fk_ok fail no schema should have the proper diagnostics
+ok 129 - fk_ok fail no schema desc should fail
+ok 130 - fk_ok fail no schema desc should have the proper description
+ok 131 - fk_ok fail no schema desc should have the proper diagnostics
+ok 132 - fk_ok bad PK test should fail
+ok 133 - fk_ok bad PK test should have the proper description
+ok 134 - fk_ok bad PK test should have the proper diagnostics
+ok 135 - double fk schema test should pass
+ok 136 - double fk schema test should have the proper description
+ok 137 - double fk schema test should have the proper diagnostics
+ok 138 - double fk test should pass
+ok 139 - double fk test should have the proper description
+ok 140 - double fk test should have the proper diagnostics
+ok 141 - double fk and col schema test should pass
+ok 142 - double fk and col schema test should have the proper description
+ok 143 - double fk and col schema test should have the proper diagnostics
+ok 144 - missing fk test should fail
+ok 145 - missing fk test should have the proper description
+ok 146 - missing fk test should have the proper diagnostics
+ok 147 - bad FK column test should fail
+ok 148 - bad FK column test should have the proper description
+ok 149 - bad FK column test should have the proper diagnostics

--- a/test/expected/pktap.out
+++ b/test/expected/pktap.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..102
+1..108
 ok 1 - has_pk( schema, table, description ) should pass
 ok 2 - has_pk( schema, table, description ) should have the proper description
 ok 3 - has_pk( schema, table, description ) should have the proper diagnostics
@@ -66,39 +66,45 @@ ok 63 - col_is_pk( schema, table, column, description ) fail should have the pro
 ok 64 - col_is_pk( table, column, description ) fail should fail
 ok 65 - col_is_pk( table, column, description ) fail should have the proper description
 ok 66 - col_is_pk( table, column, description ) fail should have the proper diagnostics
-ok 67 - col_is_pk( schema, table, column[], description ) should pass
-ok 68 - col_is_pk( schema, table, column[], description ) should have the proper description
-ok 69 - col_is_pk( schema, table, column[], description ) should have the proper diagnostics
-ok 70 - col_is_pk( schema, table, column[] ) should pass
-ok 71 - col_is_pk( schema, table, column[] ) should have the proper description
-ok 72 - col_is_pk( schema, table, column[] ) should have the proper diagnostics
-ok 73 - col_is_pk( table, column[], description ) should pass
-ok 74 - col_is_pk( table, column[], description ) should have the proper description
-ok 75 - col_is_pk( table, column[], description ) should have the proper diagnostics
-ok 76 - col_is_pk( table, column[] ) should pass
-ok 77 - col_is_pk( table, column[] ) should have the proper description
-ok 78 - col_is_pk( table, column[] ) should have the proper diagnostics
+ok 67 - col_is_pk( schema, table, columns[], description ) should pass
+ok 68 - col_is_pk( schema, table, columns[], description ) should have the proper description
+ok 69 - col_is_pk( schema, table, columns[], description ) should have the proper diagnostics
+ok 70 - col_is_pk( schema, table, columns[] ) should pass
+ok 71 - col_is_pk( schema, table, columns[] ) should have the proper description
+ok 72 - col_is_pk( schema, table, columns[] ) should have the proper diagnostics
+ok 73 - col_is_pk( table, columns[], description ) should pass
+ok 74 - col_is_pk( table, columns[], description ) should have the proper description
+ok 75 - col_is_pk( table, columns[], description ) should have the proper diagnostics
+ok 76 - col_is_pk( table, columns[] ) should pass
+ok 77 - col_is_pk( table, columns[] ) should have the proper description
+ok 78 - col_is_pk( table, columns[] ) should have the proper diagnostics
 ok 79 - col_isnt_pk( schema, table, column, description ) should fail
 ok 80 - col_isnt_pk( schema, table, column, description ) should have the proper description
 ok 81 - col_isnt_pk( schema, table, column, description ) should have the proper diagnostics
-ok 82 - col_isnt_pk( table, column, description ) should fail
-ok 83 - col_isnt_pk( table, column, description ) should have the proper description
-ok 84 - col_isnt_pk( table, column, description ) should have the proper diagnostics
-ok 85 - col_isnt_pk( table, column ) should fail
-ok 86 - col_isnt_pk( table, column ) should have the proper description
-ok 87 - col_isnt_pk( table, column ) should have the proper diagnostics
-ok 88 - col_isnt_pk( schema, table, column, description ) pass should pass
-ok 89 - col_isnt_pk( schema, table, column, description ) pass should have the proper description
-ok 90 - col_isnt_pk( schema, table, column, description ) pass should have the proper diagnostics
-ok 91 - col_isnt_pk( table, column, description ) pass should pass
-ok 92 - col_isnt_pk( table, column, description ) pass should have the proper description
-ok 93 - col_isnt_pk( table, column, description ) pass should have the proper diagnostics
-ok 94 - col_isnt_pk( schema, table, column[], description ) should pass
-ok 95 - col_isnt_pk( schema, table, column[], description ) should have the proper description
-ok 96 - col_isnt_pk( schema, table, column[], description ) should have the proper diagnostics
-ok 97 - col_isnt_pk( table, column[], description ) should pass
-ok 98 - col_isnt_pk( table, column[], description ) should have the proper description
-ok 99 - col_isnt_pk( table, column[], description ) should have the proper diagnostics
-ok 100 - col_isnt_pk( table, column[] ) should pass
-ok 101 - col_isnt_pk( table, column[] ) should have the proper description
-ok 102 - col_isnt_pk( table, column[] ) should have the proper diagnostics
+ok 82 - col_isnt_pk( schema, table, column ) should fail
+ok 83 - col_isnt_pk( schema, table, column ) should have the proper description
+ok 84 - col_isnt_pk( schema, table, column ) should have the proper diagnostics
+ok 85 - col_isnt_pk( table, column, description ) should fail
+ok 86 - col_isnt_pk( table, column, description ) should have the proper description
+ok 87 - col_isnt_pk( table, column, description ) should have the proper diagnostics
+ok 88 - col_isnt_pk( table, column ) should fail
+ok 89 - col_isnt_pk( table, column ) should have the proper description
+ok 90 - col_isnt_pk( table, column ) should have the proper diagnostics
+ok 91 - col_isnt_pk( schema, table, column, description ) pass should pass
+ok 92 - col_isnt_pk( schema, table, column, description ) pass should have the proper description
+ok 93 - col_isnt_pk( schema, table, column, description ) pass should have the proper diagnostics
+ok 94 - col_isnt_pk( table, column, description ) pass should pass
+ok 95 - col_isnt_pk( table, column, description ) pass should have the proper description
+ok 96 - col_isnt_pk( table, column, description ) pass should have the proper diagnostics
+ok 97 - col_isnt_pk( schema, table, columns[], description ) should pass
+ok 98 - col_isnt_pk( schema, table, columns[], description ) should have the proper description
+ok 99 - col_isnt_pk( schema, table, columns[], description ) should have the proper diagnostics
+ok 100 - col_isnt_pk( schema, table, columns[] ) should pass
+ok 101 - col_isnt_pk( schema, table, columns[] ) should have the proper description
+ok 102 - col_isnt_pk( schema, table, columns[] ) should have the proper diagnostics
+ok 103 - col_isnt_pk( table, columns[], description ) should pass
+ok 104 - col_isnt_pk( table, columns[], description ) should have the proper description
+ok 105 - col_isnt_pk( table, columns[], description ) should have the proper diagnostics
+ok 106 - col_isnt_pk( table, columns[] ) should pass
+ok 107 - col_isnt_pk( table, columns[] ) should have the proper description
+ok 108 - col_isnt_pk( table, columns[] ) should have the proper diagnostics

--- a/test/expected/unique.out
+++ b/test/expected/unique.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..78
+1..114
 ok 1 - has_unique( schema, table, description ) should pass
 ok 2 - has_unique( schema, table, description ) should have the proper description
 ok 3 - has_unique( schema, table, description ) should have the proper diagnostics
@@ -69,12 +69,48 @@ ok 66 - col_is_unique( schema, table, column, description ) fail should have the
 ok 67 - col_is_unique( table, column, description ) fail should fail
 ok 68 - col_is_unique( table, column, description ) fail should have the proper description
 ok 69 - col_is_unique( table, column, description ) fail should have the proper diagnostics
-ok 70 - col_is_unique( schema, table, column[], description ) should pass
-ok 71 - col_is_unique( schema, table, column[], description ) should have the proper description
-ok 72 - col_is_unique( schema, table, column[], description ) should have the proper diagnostics
-ok 73 - col_is_unique( table, column[], description ) should pass
-ok 74 - col_is_unique( table, column[], description ) should have the proper description
-ok 75 - col_is_unique( table, column[], description ) should have the proper diagnostics
-ok 76 - col_is_unique( table, column[] ) should pass
-ok 77 - col_is_unique( table, column[] ) should have the proper description
-ok 78 - col_is_unique( table, column[] ) should have the proper diagnostics
+ok 70 - col_is_unique( schema, table, columns[], description ) should pass
+ok 71 - col_is_unique( schema, table, columns[], description ) should have the proper description
+ok 72 - col_is_unique( schema, table, columns[], description ) should have the proper diagnostics
+ok 73 - col_is_unique( table, columns[], description ) should pass
+ok 74 - col_is_unique( table, columns[], description ) should have the proper description
+ok 75 - col_is_unique( table, columns[], description ) should have the proper diagnostics
+ok 76 - col_is_unique( table, columns[] ) should pass
+ok 77 - col_is_unique( table, columns[] ) should have the proper description
+ok 78 - col_is_unique( table, columns[] ) should have the proper diagnostics
+ok 79 - col_isnt_unique( schema, table, column, description ) should pass
+ok 80 - col_isnt_unique( schema, table, column, description ) should have the proper description
+ok 81 - col_isnt_unique( schema, table, column, description ) should have the proper diagnostics
+ok 82 - col_isnt_unique( schema, table, column ) should pass
+ok 83 - col_isnt_unique( schema, table, column ) should have the proper description
+ok 84 - col_isnt_unique( schema, table, column ) should have the proper diagnostics
+ok 85 - col_isnt_unique( table, column, description ) should pass
+ok 86 - col_isnt_unique( table, column, description ) should have the proper description
+ok 87 - col_isnt_unique( table, column, description ) should have the proper diagnostics
+ok 88 - col_isnt_unique( table, column ) should pass
+ok 89 - col_isnt_unique( table, column ) should have the proper description
+ok 90 - col_isnt_unique( table, column ) should have the proper diagnostics
+ok 91 - col_isnt_unique( schema, table, column, description ) fail should fail
+ok 92 - col_isnt_unique( schema, table, column, description ) fail should have the proper description
+ok 93 - col_isnt_unique( schema, table, column, description ) fail should have the proper diagnostics
+ok 94 - col_isnt_unique( table, column, description ) fail should fail
+ok 95 - col_isnt_unique( table, column, description ) fail should have the proper description
+ok 96 - col_isnt_unique( table, column, description ) fail should have the proper diagnostics
+ok 97 - col_isnt_unique( schema, table, columns[], description ) should pass
+ok 98 - col_isnt_unique( schema, table, columns[], description ) should have the proper description
+ok 99 - col_isnt_unique( schema, table, columns[], description ) should have the proper diagnostics
+ok 100 - col_isnt_unique( schema, table, columns[] ) should pass
+ok 101 - col_isnt_unique( schema, table, columns[] ) should have the proper description
+ok 102 - col_isnt_unique( schema, table, columns[] ) should have the proper diagnostics
+ok 103 - col_isnt_unique( table, columns[], description ) should pass
+ok 104 - col_isnt_unique( table, columns[], description ) should have the proper description
+ok 105 - col_isnt_unique( table, columns[], description ) should have the proper diagnostics
+ok 106 - col_isnt_unique( table, columns[] ) should pass
+ok 107 - col_isnt_unique( table, columns[] ) should have the proper description
+ok 108 - col_isnt_unique( table, columns[] ) should have the proper diagnostics
+ok 109 - col_isnt_unique( schema, table, columns[], description ) fail should fail
+ok 110 - col_isnt_unique( schema, table, columns[], description ) fail should have the proper description
+ok 111 - col_isnt_unique( schema, table, columns[], description ) fail should have the proper diagnostics
+ok 112 - col_isnt_unique( table, columns[], description ) fail should fail
+ok 113 - col_isnt_unique( table, columns[], description ) fail should have the proper description
+ok 114 - col_isnt_unique( table, columns[], description ) fail should have the proper diagnostics

--- a/test/sql/fktap.sql
+++ b/test/sql/fktap.sql
@@ -1,7 +1,7 @@
 \unset ECHO
 \i test/setup.sql
 
-SELECT plan(140);
+SELECT plan(149);
 --SELECT * from no_plan();
 
 -- These will be rolled back. :-)
@@ -188,6 +188,13 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
+    col_is_fk( 'public', 'fk', 'pk_id'::name ),
+    true,
+    'col_is_fk( schema, table, column )',
+    'Column public.fk(pk_id) should be a foreign key'
+);
+
+SELECT * FROM check_test(
     col_is_fk( 'fk', 'pk_id', 'fk.pk_id should be an fk' ),
     true,
     'col_is_fk( table, column, description )',
@@ -252,21 +259,28 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_is_fk( 'public', 'fk2', ARRAY['pk2_num', 'pk2_dot'], 'id + pk2_dot should be an fk' ),
     true,
-    'col_is_fk( schema, table, column[], description )',
+    'col_is_fk( schema, table, columns[], description )',
     'id + pk2_dot should be an fk'
+);
+
+SELECT * FROM check_test(
+    col_is_fk( 'public', 'fk2', ARRAY['pk2_num', 'pk2_dot']::name[] ),
+    true,
+    'col_is_fk( schema, table, columns[] )',
+    'Columns public.fk2(pk2_num, pk2_dot) should be a foreign key'
 );
 
 SELECT * FROM check_test(
     col_is_fk( 'fk2', ARRAY['pk2_num', 'pk2_dot'], 'id + pk2_dot should be an fk' ),
     true,
-    'col_is_fk( table, column[], description )',
+    'col_is_fk( table, columns[], description )',
     'id + pk2_dot should be an fk'
 );
 
 SELECT * FROM check_test(
     col_is_fk( 'fk2', ARRAY['pk2_num', 'pk2_dot'] ),
     true,
-    'col_is_fk( table, column[] )',
+    'col_is_fk( table, columns[] )',
     'Columns fk2(pk2_num, pk2_dot) should be a foreign key'
 );
 
@@ -279,6 +293,14 @@ SELECT * FROM check_test(
     'col_isnt_fk( schema, table, column, description )',
     'public.fk.pk_id should not be an fk',
     ''    
+);
+
+SELECT * FROM check_test(
+    col_isnt_fk( 'public', 'fk', 'pk_id'::name ),
+    false,
+    'col_isnt_fk( schema, table, column )',
+    'Column public.fk(pk_id) should not be a foreign key',
+    ''
 );
 
 SELECT * FROM check_test(
@@ -345,21 +367,28 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_isnt_fk( 'public', 'fk2', ARRAY['pk2_num', 'pk2_dot'], 'id + pk2_dot should not be an fk' ),
     false,
-    'col_isnt_fk( schema, table, column[], description )',
+    'col_isnt_fk( schema, table, columns[], description )',
     'id + pk2_dot should not be an fk'
+);
+
+SELECT * FROM check_test(
+    col_isnt_fk( 'public', 'fk2', ARRAY['pk2_num', 'pk2_dot']::name[] ),
+    false,
+    'col_isnt_fk( schema, table, columns[] )',
+    'Columns public.fk2(pk2_num, pk2_dot) should not be a foreign key'
 );
 
 SELECT * FROM check_test(
     col_isnt_fk( 'fk2', ARRAY['pk2_num', 'pk2_dot'], 'id + pk2_dot should not be an fk' ),
     false,
-    'col_isnt_fk( table, column[], description )',
+    'col_isnt_fk( table, columns[], description )',
     'id + pk2_dot should not be an fk'
 );
 
 SELECT * FROM check_test(
     col_isnt_fk( 'fk2', ARRAY['pk2_num', 'pk2_dot'] ),
     false,
-    'col_isnt_fk( table, column[] )',
+    'col_isnt_fk( table, columns[] )',
     'Columns fk2(pk2_num, pk2_dot) should not be a foreign key'
 );
 

--- a/test/sql/pktap.sql
+++ b/test/sql/pktap.sql
@@ -2,7 +2,7 @@
 \i test/setup.sql
 -- \i sql/pgtap.sql
 
-SELECT plan(102);
+SELECT plan(108);
 --SELECT * FROM no_plan();
 
 -- This will be rolled back. :-)
@@ -228,7 +228,7 @@ RESET client_min_messages;
 SELECT * FROM check_test(
     col_is_pk( 'public', 'argh', ARRAY['id', 'name'], 'id + name should be a pk' ),
     true,
-    'col_is_pk( schema, table, column[], description )',
+    'col_is_pk( schema, table, columns[], description )',
     'id + name should be a pk',
     ''
 );
@@ -236,7 +236,7 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_is_pk( 'public', 'argh', ARRAY['id', 'name']::name[] ),
     true,
-    'col_is_pk( schema, table, column[] )',
+    'col_is_pk( schema, table, columns[] )',
     'Columns public.argh(id, name) should be a primary key',
     ''
 );
@@ -244,7 +244,7 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_is_pk( 'argh', ARRAY['id', 'name'], 'id + name should be a pk' ),
     true,
-    'col_is_pk( table, column[], description )',
+    'col_is_pk( table, columns[], description )',
     'id + name should be a pk',
     ''
 );
@@ -252,7 +252,7 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_is_pk( 'argh', ARRAY['id', 'name'] ),
     true,
-    'col_is_pk( table, column[] )',
+    'col_is_pk( table, columns[] )',
     'Columns argh(id, name) should be a primary key',
     ''
 );
@@ -265,6 +265,15 @@ SELECT * FROM check_test(
     false,
     'col_isnt_pk( schema, table, column, description )',
     'public.sometab.id should not be a pk',
+    '        have: {id}
+        want: anything else'
+);
+
+SELECT * FROM check_test(
+    col_isnt_pk( 'public', 'sometab', 'id'::name ),
+    false,
+    'col_isnt_pk( schema, table, column )',
+    'Column public.sometab(id) should not be a primary key',
     '        have: {id}
         want: anything else'
 );
@@ -309,15 +318,23 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_isnt_pk( 'public', 'argh', ARRAY['id', 'foo'], 'id + foo should not be a pk' ),
     true,
-    'col_isnt_pk( schema, table, column[], description )',
+    'col_isnt_pk( schema, table, columns[], description )',
     'id + foo should not be a pk',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_pk( 'public', 'argh', ARRAY['id', 'foo']::name[] ),
+    true,
+    'col_isnt_pk( schema, table, columns[] )',
+    'Columns public.argh(id, foo) should not be a primary key',
     ''
 );
 
 SELECT * FROM check_test(
     col_isnt_pk( 'argh', ARRAY['id', 'foo'], 'id + foo should not be a pk' ),
     true,
-    'col_isnt_pk( table, column[], description )',
+    'col_isnt_pk( table, columns[], description )',
     'id + foo should not be a pk',
     ''
 );
@@ -325,7 +342,7 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_isnt_pk( 'argh', ARRAY['id', 'foo'] ),
     true,
-    'col_isnt_pk( table, column[] )',
+    'col_isnt_pk( table, columns[] )',
     'Columns argh(id, foo) should not be a primary key',
     ''
 );

--- a/test/sql/unique.sql
+++ b/test/sql/unique.sql
@@ -1,7 +1,7 @@
 \unset ECHO
 \i test/setup.sql
 
-SELECT plan(78);
+SELECT plan(114);
 
 -- This will be rolled back. :-)
 SET client_min_messages = warning;
@@ -229,7 +229,7 @@ RESET client_min_messages;
 SELECT * FROM check_test(
     col_is_unique( 'public', 'argh', ARRAY['id', 'name'], 'id + name should be unique' ),
     true,
-    'col_is_unique( schema, table, column[], description )',
+    'col_is_unique( schema, table, columns[], description )',
     'id + name should be unique',
     ''
 );
@@ -237,7 +237,7 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_is_unique( 'argh', ARRAY['id', 'name'], 'id + name should be unique' ),
     true,
-    'col_is_unique( table, column[], description )',
+    'col_is_unique( table, columns[], description )',
     'id + name should be unique',
     ''
 );
@@ -245,8 +245,110 @@ SELECT * FROM check_test(
 SELECT * FROM check_test(
     col_is_unique( 'argh', ARRAY['id', 'name'] ),
     true,
-    'col_is_unique( table, column[] )',
+    'col_is_unique( table, columns[] )',
     'Columns argh(id, name) should have a unique constraint',
+    ''
+);
+
+/****************************************************************************/
+-- Test col_isnt_unique().
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'public', 'sometab', 'id', 'public.sometab.id should not be unique' ),
+    true,
+    'col_isnt_unique( schema, table, column, description )',
+    'public.sometab.id should not be unique',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'public', 'sometab', 'id'::name ),
+    true,
+    'col_isnt_unique( schema, table, column )',
+    'Column sometab(id) should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'sometab', 'id', 'sometab.id should not be unique' ),
+    true,
+    'col_isnt_unique( table, column, description )',
+    'sometab.id should not be unique',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'sometab', 'id' ),
+    true,
+    'col_isnt_unique( table, column )',
+    'Column sometab(id) should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'public', 'sometab', 'name', 'public.sometab.name should not be unique' ),
+    false,
+    'col_isnt_unique( schema, table, column, description ) fail',
+    'public.sometab.name should not be unique',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'sometab', 'name', 'sometab.name should not be unique' ),
+    false,
+    'col_isnt_unique( table, column, description ) fail',
+    'sometab.name should not be unique',
+    ''
+);
+
+/****************************************************************************/
+-- Test col_isnt_unique() with an array of columns.
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'public', 'argh', ARRAY['id', 'foo'], 'id + foo should not be unique' ),
+    true,
+    'col_isnt_unique( schema, table, columns[], description )',
+    'id + foo should not be unique',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'public', 'argh', ARRAY['id', 'foo']::name[] ),
+    true,
+    'col_isnt_unique( schema, table, columns[] )',
+    'Columns argh(id, foo) should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'argh', ARRAY['id', 'foo'], 'id + foo should not be unique' ),
+    true,
+    'col_isnt_unique( table, columns[], description )',
+    'id + foo should not be unique',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'argh', ARRAY['id', 'foo'] ),
+    true,
+    'col_isnt_unique( table, columns[] )',
+    'Columns argh(id, foo) should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'public', 'argh', ARRAY['id', 'name'], 'id + name should not be unique' ),
+    false,
+    'col_isnt_unique( schema, table, columns[], description ) fail',
+    'id + name should not be unique',
+    ''
+);
+
+SELECT * FROM check_test(
+    col_isnt_unique( 'argh', ARRAY['id', 'name'], 'id + name should not be unique' ),
+    false,
+    'col_isnt_unique( table, columns[], description ) fail',
+    'id + name should not be unique',
     ''
 );
 


### PR DESCRIPTION
Closes #363 [1/3]

As discussed this is the first part of the PR split -> implementation symmetry.

All 3 now follow:
```sql
-- col_is{nt}_X( schema, table, column[], description ) -- ( NAME, NAME, NAME[], TEXT )
-- col_is{nt}_X( schema, table, column[] )              -- ( NAME, NAME, NAME[] )
-- col_is{nt}_X( table, column[], description )         -- ( NAME, NAME[], TEXT )
-- col_is{nt}_X( table, column[] )                      -- ( NAME, NAME[] )
-- col_is{nt}_X( schema, table, column, description )   -- ( NAME, NAME, NAME, TEXT )
-- col_is{nt}_X( schema, table, column )                -- ( NAME, NAME, NAME )
-- col_is{nt}_X( table, column, description )           -- ( NAME, NAME, TEXT )
-- col_is{nt}_X( table, column )                        -- ( NAME, NAME )
```

EDIT: `col_is_null` isn't in scope because you went the `is`/`not` instead of `is`/`isnt` so I didn't think it was pertinent. If you disagree I can conform it as well I suppose.