### PR TITLE
Improved has{nt}_X implementation

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ Revision history for pgTAP
   has upgraded its Markdown parser.
 * Added an example of an empty array, `'{}'::name[]`, to each mention in the
   documentation. Thanks Kevin Brannen for the suggestion (#362).
+* Added missing `schema, table` variants of `hasnt_pk()`, `has_fk()`,
+  `hasnt_fk()`, `has_unique()`, and `has_check()`, and added `hasnt_unique()`
+  and `hasnt_check()`. Also changed `has_unique()` argument types from `TEXT`
+  to `NAME` so they can share a consistent overload order with the other
+  constraint assertions. Thanks to @RampantDespair for the PR (#370).
 
 1.3.4 2025-10-04T17:20:28Z
 --------------------------

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -5121,6 +5121,7 @@ SELECT has_pk( 'myschema', 'mytable'::name );
 
 ```sql
 SELECT hasnt_pk( :schema, :table, :description );
+SELECT hasnt_pk( :schema, :table );
 SELECT hasnt_pk( :table, :description );
 SELECT hasnt_pk( :table );
 ```
@@ -5143,6 +5144,7 @@ primary key does *not* exist.
 
 ```sql
 SELECT has_fk( :schema, :table, :description );
+SELECT has_fk( :schema, :table );
 SELECT has_fk( :table, :description );
 SELECT has_fk( :table );
 ```
@@ -5169,6 +5171,7 @@ table in question does not exist.
 
 ```sql
 SELECT hasnt_fk( :schema, :table, :description );
+SELECT hasnt_fk( :schema, :table );
 SELECT hasnt_fk( :table, :description );
 SELECT hasnt_fk( :table );
 ```
@@ -5441,6 +5444,7 @@ Will produce something like this:
 
 ```sql
 SELECT has_unique( :schema, :table, :description );
+SELECT has_unique( :schema, :table );
 SELECT has_unique( :table, :description );
 SELECT has_unique( :table );
 ```
@@ -5462,6 +5466,29 @@ description. If the schema is omitted, the table must be visible in the search
 path. If the test description is omitted, it will be set to "Table `:table`
 should have a unique constraint". Note that this test will fail if the table
 in question does not exist.
+
+### `hasnt_unique()` ###
+
+```sql
+SELECT hasnt_unique( :schema, :table, :description );
+SELECT hasnt_unique( :schema, :table );
+SELECT hasnt_unique( :table, :description );
+SELECT hasnt_unique( :table );
+```
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the table.
+
+`:table`
+: Name of a table.
+
+`:description`
+: A short description of the test.
+
+This function is the inverse of `has_unique()`. The test passes if the
+specified unique constraint does *not* exist.
 
 ### `col_is_unique()` ###
 
@@ -5524,6 +5551,7 @@ were actually found, if any:
 
 ```sql
 SELECT has_check( :schema, :table, :description );
+SELECT has_check( :schema, :table );
 SELECT has_check( :table, :description );
 SELECT has_check( :table );
 ```
@@ -5552,6 +5580,29 @@ that do have check constraints, if any:
     Failed test 41: "users.email should have a check constraint"
             have: {username}
             want: {email}
+
+### `hasnt_check()` ###
+
+```sql
+SELECT hasnt_check( :schema, :table, :description );
+SELECT hasnt_check( :schema, :table );
+SELECT hasnt_check( :table, :description );
+SELECT hasnt_check( :table );
+```
+
+**Parameters**
+
+`:schema`
+: Schema in which to find the table.
+
+`:table`
+: Name of a table.
+
+`:description`
+: A short description of the test.
+
+This function is the inverse of `has_check()`. The test passes if the
+specified check constraint does *not* exist.
 
 ### `col_has_check()` ###
 

--- a/sql/pgtap--1.3.4--1.3.5.sql
+++ b/sql/pgtap--1.3.4--1.3.5.sql
@@ -1,1 +1,102 @@
 -- Changes between pgTAP v1.3.4 and v1.3.5.
+
+-- hasnt_pk( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_pk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_pk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a primary key' );
+$$ LANGUAGE sql;
+
+-- has_fk( schema, table )
+CREATE OR REPLACE FUNCTION has_fk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_fk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a foreign key constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_fk( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_fk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_fk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a foreign key constraint' );
+$$ LANGUAGE sql;
+
+-- Replace has_unique(TEXT...) with has_unique(NAME...) so (schema, table) can be overloaded.
+DROP FUNCTION has_unique ( TEXT, TEXT, TEXT );
+DROP FUNCTION has_unique ( TEXT, TEXT );
+DROP FUNCTION has_unique ( TEXT );
+
+-- has_unique( schema, table, description )
+CREATE OR REPLACE FUNCTION has_unique ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( _hasc( $1, $2, 'u' ), $3 );
+$$ LANGUAGE sql;
+
+-- has_unique( schema, table )
+CREATE OR REPLACE FUNCTION has_unique ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_unique( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- has_unique( table, description )
+CREATE OR REPLACE FUNCTION has_unique ( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( _hasc( $1, 'u' ), $2 );
+$$ LANGUAGE sql;
+
+-- has_unique( table )
+CREATE OR REPLACE FUNCTION has_unique ( NAME )
+RETURNS TEXT AS $$
+    SELECT has_unique( $1, 'Table ' || quote_ident($1) || ' should have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( schema, table, description )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, $2, 'u' ), $3 );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_unique( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( table, description )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, 'u' ), $2 );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( table )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_unique( $1, 'Table ' || quote_ident($1) || ' should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- has_check( schema, table )
+CREATE OR REPLACE FUNCTION has_check ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_check( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a check constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_check( schema, table, description )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, $2, 'c' ), $3 );
+$$ LANGUAGE sql;
+
+-- hasnt_check( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_check( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a check constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_check( table, description )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, 'c' ), $2 );
+$$ LANGUAGE sql;
+
+-- hasnt_check( table )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_check( $1, 'Table ' || quote_ident($1) || ' should not have a check constraint' );
+$$ LANGUAGE sql;

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -1899,6 +1899,12 @@ RETURNS TEXT AS $$
     SELECT ok( NOT _hasc( $1, $2, 'p' ), $3 );
 $$ LANGUAGE sql;
 
+-- hasnt_pk( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_pk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_pk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a primary key' );
+$$ LANGUAGE sql;
+
 -- hasnt_pk( table, description )
 CREATE OR REPLACE FUNCTION hasnt_pk ( NAME, TEXT )
 RETURNS TEXT AS $$
@@ -2140,6 +2146,12 @@ RETURNS TEXT AS $$
     SELECT ok( _hasc( $1, $2, 'f' ), $3 );
 $$ LANGUAGE sql;
 
+-- has_fk( schema, table )
+CREATE OR REPLACE FUNCTION has_fk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_fk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a foreign key constraint' );
+$$ LANGUAGE sql;
+
 -- has_fk( table, description )
 CREATE OR REPLACE FUNCTION has_fk ( NAME, TEXT )
 RETURNS TEXT AS $$
@@ -2156,6 +2168,12 @@ $$ LANGUAGE sql;
 CREATE OR REPLACE FUNCTION hasnt_fk ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT ok( NOT _hasc( $1, $2, 'f' ), $3 );
+$$ LANGUAGE sql;
+
+-- hasnt_fk( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_fk ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_fk( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a foreign key constraint' );
 $$ LANGUAGE sql;
 
 -- hasnt_fk( table, description )
@@ -2318,21 +2336,51 @@ RETURNS TEXT AS $$
 $$ LANGUAGE sql;
 
 -- has_unique( schema, table, description )
-CREATE OR REPLACE FUNCTION has_unique ( TEXT, TEXT, TEXT )
+CREATE OR REPLACE FUNCTION has_unique ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT ok( _hasc( $1, $2, 'u' ), $3 );
 $$ LANGUAGE sql;
 
+-- has_unique( schema, table )
+CREATE OR REPLACE FUNCTION has_unique ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_unique( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a unique constraint' );
+$$ LANGUAGE sql;
+
 -- has_unique( table, description )
-CREATE OR REPLACE FUNCTION has_unique ( TEXT, TEXT )
+CREATE OR REPLACE FUNCTION has_unique ( NAME, TEXT )
 RETURNS TEXT AS $$
     SELECT ok( _hasc( $1, 'u' ), $2 );
 $$ LANGUAGE sql;
 
 -- has_unique( table )
-CREATE OR REPLACE FUNCTION has_unique ( TEXT )
+CREATE OR REPLACE FUNCTION has_unique ( NAME )
 RETURNS TEXT AS $$
     SELECT has_unique( $1, 'Table ' || quote_ident($1) || ' should have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( schema, table, description )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, $2, 'u' ), $3 );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_unique( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a unique constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( table, description )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, 'u' ), $2 );
+$$ LANGUAGE sql;
+
+-- hasnt_unique( table )
+CREATE OR REPLACE FUNCTION hasnt_unique ( NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_unique( $1, 'Table ' || quote_ident($1) || ' should not have a unique constraint' );
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION _constraint ( NAME, NAME, CHAR, NAME[], TEXT, TEXT )
@@ -2437,6 +2485,12 @@ RETURNS TEXT AS $$
     SELECT ok( _hasc( $1, $2, 'c' ), $3 );
 $$ LANGUAGE sql;
 
+-- has_check( schema, table )
+CREATE OR REPLACE FUNCTION has_check ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT has_check( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should have a check constraint' );
+$$ LANGUAGE sql;
+
 -- has_check( table, description )
 CREATE OR REPLACE FUNCTION has_check ( NAME, TEXT )
 RETURNS TEXT AS $$
@@ -2447,6 +2501,30 @@ $$ LANGUAGE sql;
 CREATE OR REPLACE FUNCTION has_check ( NAME )
 RETURNS TEXT AS $$
     SELECT has_check( $1, 'Table ' || quote_ident($1) || ' should have a check constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_check( schema, table, description )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, $2, 'c' ), $3 );
+$$ LANGUAGE sql;
+
+-- hasnt_check( schema, table )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_check( $1, $2, 'Table ' || quote_ident($1) || '.' || quote_ident($2) || ' should not have a check constraint' );
+$$ LANGUAGE sql;
+
+-- hasnt_check( table, description )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME, TEXT )
+RETURNS TEXT AS $$
+    SELECT ok( NOT _hasc( $1, 'c' ), $2 );
+$$ LANGUAGE sql;
+
+-- hasnt_check( table )
+CREATE OR REPLACE FUNCTION hasnt_check ( NAME )
+RETURNS TEXT AS $$
+    SELECT hasnt_check( $1, 'Table ' || quote_ident($1) || ' should not have a check constraint' );
 $$ LANGUAGE sql;
 
 -- col_has_check( schema, table, column, description )

--- a/test/expected/check.out
+++ b/test/expected/check.out
@@ -1,50 +1,74 @@
 \unset ECHO
-1..48
+1..72
 ok 1 - has_check( schema, table, desc ) should pass
 ok 2 - has_check( schema, table, desc ) should have the proper description
 ok 3 - has_check( schema, table, desc ) should have the proper diagnostics
-ok 4 - has_check( table, desc ) should pass
-ok 5 - has_check( table, desc ) should have the proper description
-ok 6 - has_check( table, desc ) should have the proper diagnostics
-ok 7 - has_check( table ) should pass
-ok 8 - has_check( table ) should have the proper description
-ok 9 - has_check( table ) should have the proper diagnostics
-ok 10 - has_check( schema, table, descr ) fail should fail
-ok 11 - has_check( schema, table, descr ) fail should have the proper description
-ok 12 - has_check( schema, table, descr ) fail should have the proper diagnostics
-ok 13 - has_check( table, desc ) fail should fail
-ok 14 - has_check( table, desc ) fail should have the proper description
-ok 15 - has_check( table, desc ) fail should have the proper diagnostics
-ok 16 - col_has_check( sch, tab, col, desc ) should pass
-ok 17 - col_has_check( sch, tab, col, desc ) should have the proper description
-ok 18 - col_has_check( sch, tab, col, desc ) should have the proper diagnostics
-ok 19 - col_has_check( sch, tab, cols, desc ) should pass
-ok 20 - col_has_check( sch, tab, cols, desc ) should have the proper description
-ok 21 - col_has_check( sch, tab, cols, desc ) should have the proper diagnostics
-ok 22 - col_has_check( tab, col, desc ) should pass
-ok 23 - col_has_check( tab, col, desc ) should have the proper description
-ok 24 - col_has_check( tab, col, desc ) should have the proper diagnostics
-ok 25 - col_has_check( tab, cols, desc ) should pass
-ok 26 - col_has_check( tab, cols, desc ) should have the proper description
-ok 27 - col_has_check( tab, cols, desc ) should have the proper diagnostics
-ok 28 - col_has_check( table, column ) should pass
-ok 29 - col_has_check( table, column ) should have the proper description
-ok 30 - col_has_check( table, column ) should have the proper diagnostics
-ok 31 - col_has_check( table, columns ) should pass
-ok 32 - col_has_check( table, columns ) should have the proper description
-ok 33 - col_has_check( table, columns ) should have the proper diagnostics
-ok 34 - col_has_check( sch, tab, col, desc ) fail should fail
-ok 35 - col_has_check( sch, tab, col, desc ) fail should have the proper description
-ok 36 - col_has_check( sch, tab, col, desc ) fail should have the proper diagnostics
-ok 37 - col_has_check( tab, col, desc ) fail should fail
-ok 38 - col_has_check( tab, col, desc ) fail should have the proper description
-ok 39 - col_has_check( tab, col, desc ) fail should have the proper diagnostics
-ok 40 - col_has_check( sch, tab, col[], desc ) should pass
-ok 41 - col_has_check( sch, tab, col[], desc ) should have the proper description
-ok 42 - col_has_check( sch, tab, col[], desc ) should have the proper diagnostics
-ok 43 - col_has_check( tab, col[], desc ) should pass
-ok 44 - col_has_check( tab, col[], desc ) should have the proper description
-ok 45 - col_has_check( tab, col[], desc ) should have the proper diagnostics
-ok 46 - col_has_check( tab, col[] ) should pass
-ok 47 - col_has_check( tab, col[] ) should have the proper description
-ok 48 - col_has_check( tab, col[] ) should have the proper diagnostics
+ok 4 - has_check( schema, table ) should pass
+ok 5 - has_check( schema, table ) should have the proper description
+ok 6 - has_check( schema, table ) should have the proper diagnostics
+ok 7 - has_check( table, desc ) should pass
+ok 8 - has_check( table, desc ) should have the proper description
+ok 9 - has_check( table, desc ) should have the proper diagnostics
+ok 10 - has_check( table ) should pass
+ok 11 - has_check( table ) should have the proper description
+ok 12 - has_check( table ) should have the proper diagnostics
+ok 13 - has_check( schema, table, descr ) fail should fail
+ok 14 - has_check( schema, table, descr ) fail should have the proper description
+ok 15 - has_check( schema, table, descr ) fail should have the proper diagnostics
+ok 16 - has_check( table, desc ) fail should fail
+ok 17 - has_check( table, desc ) fail should have the proper description
+ok 18 - has_check( table, desc ) fail should have the proper diagnostics
+ok 19 - hasnt_check( schema, table, description ) should fail
+ok 20 - hasnt_check( schema, table, description ) should have the proper description
+ok 21 - hasnt_check( schema, table, description ) should have the proper diagnostics
+ok 22 - hasnt_check( schema, table ) should fail
+ok 23 - hasnt_check( schema, table ) should have the proper description
+ok 24 - hasnt_check( schema, table ) should have the proper diagnostics
+ok 25 - hasnt_check( table, description ) should fail
+ok 26 - hasnt_check( table, description ) should have the proper description
+ok 27 - hasnt_check( table, description ) should have the proper diagnostics
+ok 28 - hasnt_check( table ) should fail
+ok 29 - hasnt_check( table ) should have the proper description
+ok 30 - hasnt_check( table ) should have the proper diagnostics
+ok 31 - hasnt_check( schema, table, description ) pass should pass
+ok 32 - hasnt_check( schema, table, description ) pass should have the proper description
+ok 33 - hasnt_check( schema, table, description ) pass should have the proper diagnostics
+ok 34 - hasnt_check( schema, table ) pass should pass
+ok 35 - hasnt_check( schema, table ) pass should have the proper description
+ok 36 - hasnt_check( schema, table ) pass should have the proper diagnostics
+ok 37 - hasnt_check( table, description ) pass should pass
+ok 38 - hasnt_check( table, description ) pass should have the proper description
+ok 39 - hasnt_check( table, description ) pass should have the proper diagnostics
+ok 40 - col_has_check( sch, tab, col, desc ) should pass
+ok 41 - col_has_check( sch, tab, col, desc ) should have the proper description
+ok 42 - col_has_check( sch, tab, col, desc ) should have the proper diagnostics
+ok 43 - col_has_check( sch, tab, cols, desc ) should pass
+ok 44 - col_has_check( sch, tab, cols, desc ) should have the proper description
+ok 45 - col_has_check( sch, tab, cols, desc ) should have the proper diagnostics
+ok 46 - col_has_check( tab, col, desc ) should pass
+ok 47 - col_has_check( tab, col, desc ) should have the proper description
+ok 48 - col_has_check( tab, col, desc ) should have the proper diagnostics
+ok 49 - col_has_check( tab, cols, desc ) should pass
+ok 50 - col_has_check( tab, cols, desc ) should have the proper description
+ok 51 - col_has_check( tab, cols, desc ) should have the proper diagnostics
+ok 52 - col_has_check( table, column ) should pass
+ok 53 - col_has_check( table, column ) should have the proper description
+ok 54 - col_has_check( table, column ) should have the proper diagnostics
+ok 55 - col_has_check( table, columns ) should pass
+ok 56 - col_has_check( table, columns ) should have the proper description
+ok 57 - col_has_check( table, columns ) should have the proper diagnostics
+ok 58 - col_has_check( sch, tab, col, desc ) fail should fail
+ok 59 - col_has_check( sch, tab, col, desc ) fail should have the proper description
+ok 60 - col_has_check( sch, tab, col, desc ) fail should have the proper diagnostics
+ok 61 - col_has_check( tab, col, desc ) fail should fail
+ok 62 - col_has_check( tab, col, desc ) fail should have the proper description
+ok 63 - col_has_check( tab, col, desc ) fail should have the proper diagnostics
+ok 64 - col_has_check( sch, tab, col[], desc ) should pass
+ok 65 - col_has_check( sch, tab, col[], desc ) should have the proper description
+ok 66 - col_has_check( sch, tab, col[], desc ) should have the proper diagnostics
+ok 67 - col_has_check( tab, col[], desc ) should pass
+ok 68 - col_has_check( tab, col[], desc ) should have the proper description
+ok 69 - col_has_check( tab, col[], desc ) should have the proper diagnostics
+ok 70 - col_has_check( tab, col[] ) should pass
+ok 71 - col_has_check( tab, col[] ) should have the proper description
+ok 72 - col_has_check( tab, col[] ) should have the proper diagnostics

--- a/test/expected/fktap.out
+++ b/test/expected/fktap.out
@@ -1,136 +1,142 @@
 \unset ECHO
-1..134
+1..140
 ok 1 - has_fk( schema, table, description ) should pass
 ok 2 - has_fk( schema, table, description ) should have the proper description
-ok 3 - has_fk( table, description ) should pass
-ok 4 - has_fk( table, description ) should have the proper description
-ok 5 - has_fk( table4, description ) should pass
-ok 6 - has_fk( table4, description ) should have the proper description
-ok 7 - has_fk( schema, table4, description ) should pass
-ok 8 - has_fk( schema, table4, description ) should have the proper description
-ok 9 - has_fk( table ) should pass
-ok 10 - has_fk( table ) should have the proper description
-ok 11 - has_fk( schema, table, description ) fail should fail
-ok 12 - has_fk( schema, table, description ) fail should have the proper description
-ok 13 - has_fk( table, description ) fail should fail
-ok 14 - has_fk( table, description ) fail should have the proper description
-ok 15 - hasnt_fk( schema, table, description ) should fail
-ok 16 - hasnt_fk( schema, table, description ) should have the proper description
-ok 17 - hasnt_fk( table, description ) should fail
-ok 18 - hasnt_fk( table, description ) should have the proper description
-ok 19 - hasnt_fk( table ) should fail
-ok 20 - hasnt_fk( table ) should have the proper description
-ok 21 - hasnt_fk( schema, table, description ) pass should pass
-ok 22 - hasnt_fk( schema, table, description ) pass should have the proper description
-ok 23 - hasnt_fk( table, description ) pass should pass
-ok 24 - hasnt_fk( table, description ) pass should have the proper description
-ok 25 - col_is_fk( schema, table, column, description ) should pass
-ok 26 - col_is_fk( schema, table, column, description ) should have the proper description
-ok 27 - col_is_fk( table, column, description ) should pass
-ok 28 - col_is_fk( table, column, description ) should have the proper description
-ok 29 - col_is_fk( table, column ) should pass
-ok 30 - col_is_fk( table, column ) should have the proper description
-ok 31 - col_is_fk( schema, table, column, description ) should fail
+ok 3 - has_fk( schema, table ) should pass
+ok 4 - has_fk( schema, table ) should have the proper description
+ok 5 - has_fk( table, description ) should pass
+ok 6 - has_fk( table, description ) should have the proper description
+ok 7 - has_fk( table4, description ) should pass
+ok 8 - has_fk( table4, description ) should have the proper description
+ok 9 - has_fk( schema, table4, description ) should pass
+ok 10 - has_fk( schema, table4, description ) should have the proper description
+ok 11 - has_fk( table ) should pass
+ok 12 - has_fk( table ) should have the proper description
+ok 13 - has_fk( schema, table, description ) fail should fail
+ok 14 - has_fk( schema, table, description ) fail should have the proper description
+ok 15 - has_fk( table, description ) fail should fail
+ok 16 - has_fk( table, description ) fail should have the proper description
+ok 17 - hasnt_fk( schema, table, description ) should fail
+ok 18 - hasnt_fk( schema, table, description ) should have the proper description
+ok 19 - hasnt_fk( schema, table ) should fail
+ok 20 - hasnt_fk( schema, table ) should have the proper description
+ok 21 - hasnt_fk( table, description ) should fail
+ok 22 - hasnt_fk( table, description ) should have the proper description
+ok 23 - hasnt_fk( table ) should fail
+ok 24 - hasnt_fk( table ) should have the proper description
+ok 25 - hasnt_fk( schema, table, description ) pass should pass
+ok 26 - hasnt_fk( schema, table, description ) pass should have the proper description
+ok 27 - hasnt_fk( schema, table ) pass should pass
+ok 28 - hasnt_fk( schema, table ) pass should have the proper description
+ok 29 - hasnt_fk( table, description ) pass should pass
+ok 30 - hasnt_fk( table, description ) pass should have the proper description
+ok 31 - col_is_fk( schema, table, column, description ) should pass
 ok 32 - col_is_fk( schema, table, column, description ) should have the proper description
-ok 33 - col_is_fk( schema, table, column, description ) should have the proper diagnostics
-ok 34 - col_is_fk( table, column, description ) should fail
-ok 35 - col_is_fk( table, column, description ) should have the proper description
-ok 36 - col_is_fk( table, column, description ) should have the proper diagnostics
-ok 37 - multi-fk col_is_fk test should pass
-ok 38 - multi-fk col_is_fk test should have the proper description
-ok 39 - col_is_fk with no FKs should fail
-ok 40 - col_is_fk with no FKs should have the proper description
-ok 41 - col_is_fk with no FKs should have the proper diagnostics
-ok 42 - col_is_fk with no FKs should fail
-ok 43 - col_is_fk with no FKs should have the proper description
-ok 44 - col_is_fk with no FKs should have the proper diagnostics
-ok 45 - col_is_fk( schema, table, column[], description ) should pass
-ok 46 - col_is_fk( schema, table, column[], description ) should have the proper description
-ok 47 - col_is_fk( table, column[], description ) should pass
-ok 48 - col_is_fk( table, column[], description ) should have the proper description
-ok 49 - col_is_fk( table, column[] ) should pass
-ok 50 - col_is_fk( table, column[] ) should have the proper description
-ok 51 - col_isnt_fk( schema, table, column, description ) should fail
-ok 52 - col_isnt_fk( schema, table, column, description ) should have the proper description
-ok 53 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
-ok 54 - col_isnt_fk( table, column, description ) should fail
-ok 55 - col_isnt_fk( table, column, description ) should have the proper description
-ok 56 - col_isnt_fk( table, column, description ) should have the proper diagnostics
-ok 57 - col_isnt_fk( table, column ) should fail
-ok 58 - col_isnt_fk( table, column ) should have the proper description
-ok 59 - col_isnt_fk( table, column ) should have the proper diagnostics
-ok 60 - col_isnt_fk( schema, table, column, description ) should pass
-ok 61 - col_isnt_fk( schema, table, column, description ) should have the proper description
-ok 62 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
-ok 63 - col_isnt_fk( table, column, description ) should pass
-ok 64 - col_isnt_fk( table, column, description ) should have the proper description
-ok 65 - col_isnt_fk( table, column, description ) should have the proper diagnostics
-ok 66 - multi-fk col_isnt_fk test should fail
-ok 67 - multi-fk col_isnt_fk test should have the proper description
-ok 68 - multi-fk col_isnt_fk test should have the proper diagnostics
-ok 69 - col_isnt_fk with no FKs should pass
-ok 70 - col_isnt_fk with no FKs should have the proper description
-ok 71 - col_isnt_fk with no FKs should have the proper diagnostics
-ok 72 - col_isnt_fk with no FKs should pass
-ok 73 - col_isnt_fk with no FKs should have the proper description
-ok 74 - col_isnt_fk with no FKs should have the proper diagnostics
-ok 75 - col_isnt_fk( schema, table, column[], description ) should fail
-ok 76 - col_isnt_fk( schema, table, column[], description ) should have the proper description
-ok 77 - col_isnt_fk( table, column[], description ) should fail
-ok 78 - col_isnt_fk( table, column[], description ) should have the proper description
-ok 79 - col_isnt_fk( table, column[] ) should fail
-ok 80 - col_isnt_fk( table, column[] ) should have the proper description
-ok 81 - full fk_ok array should pass
-ok 82 - full fk_ok array should have the proper description
-ok 83 - pg_my_temp_schema() should pass
-ok 84 - pg_my_temp_schema() should have the proper description
-ok 85 - multiple fk fk_ok desc should pass
-ok 86 - multiple fk fk_ok desc should have the proper description
-ok 87 - fk_ok array desc should pass
-ok 88 - fk_ok array desc should have the proper description
-ok 89 - fk_ok array noschema desc should pass
-ok 90 - fk_ok array noschema desc should have the proper description
-ok 91 - multiple fk fk_ok noschema desc should pass
-ok 92 - multiple fk fk_ok noschema desc should have the proper description
-ok 93 - fk_ok array noschema should pass
-ok 94 - fk_ok array noschema should have the proper description
-ok 95 - basic fk_ok should pass
-ok 96 - basic fk_ok should have the proper description
-ok 97 - basic fk_ok desc should pass
-ok 98 - basic fk_ok desc should have the proper description
-ok 99 - basic fk_ok noschema should pass
-ok 100 - basic fk_ok noschema should have the proper description
-ok 101 - basic fk_ok noschema desc should pass
-ok 102 - basic fk_ok noschema desc should have the proper description
-ok 103 - basic fk_ok noschema desc should have the proper diagnostics
-ok 104 - Test should pass
-ok 105 - fk_ok fail should fail
-ok 106 - fk_ok fail should have the proper description
-ok 107 - fk_ok fail should have the proper diagnostics
-ok 108 - fk_ok fail desc should fail
-ok 109 - fk_ok fail desc should have the proper description
-ok 110 - fk_ok fail desc should have the proper diagnostics
-ok 111 - fk_ok fail no schema should fail
-ok 112 - fk_ok fail no schema should have the proper description
-ok 113 - fk_ok fail no schema should have the proper diagnostics
-ok 114 - fk_ok fail no schema desc should fail
-ok 115 - fk_ok fail no schema desc should have the proper description
-ok 116 - fk_ok fail no schema desc should have the proper diagnostics
-ok 117 - fk_ok bad PK test should fail
-ok 118 - fk_ok bad PK test should have the proper description
-ok 119 - fk_ok bad PK test should have the proper diagnostics
-ok 120 - double fk schema test should pass
-ok 121 - double fk schema test should have the proper description
-ok 122 - double fk schema test should have the proper diagnostics
-ok 123 - double fk test should pass
-ok 124 - double fk test should have the proper description
-ok 125 - double fk test should have the proper diagnostics
-ok 126 - double fk and col schema test should pass
-ok 127 - double fk and col schema test should have the proper description
-ok 128 - double fk and col schema test should have the proper diagnostics
-ok 129 - missing fk test should fail
-ok 130 - missing fk test should have the proper description
-ok 131 - missing fk test should have the proper diagnostics
-ok 132 - bad FK column test should fail
-ok 133 - bad FK column test should have the proper description
-ok 134 - bad FK column test should have the proper diagnostics
+ok 33 - col_is_fk( table, column, description ) should pass
+ok 34 - col_is_fk( table, column, description ) should have the proper description
+ok 35 - col_is_fk( table, column ) should pass
+ok 36 - col_is_fk( table, column ) should have the proper description
+ok 37 - col_is_fk( schema, table, column, description ) should fail
+ok 38 - col_is_fk( schema, table, column, description ) should have the proper description
+ok 39 - col_is_fk( schema, table, column, description ) should have the proper diagnostics
+ok 40 - col_is_fk( table, column, description ) should fail
+ok 41 - col_is_fk( table, column, description ) should have the proper description
+ok 42 - col_is_fk( table, column, description ) should have the proper diagnostics
+ok 43 - multi-fk col_is_fk test should pass
+ok 44 - multi-fk col_is_fk test should have the proper description
+ok 45 - col_is_fk with no FKs should fail
+ok 46 - col_is_fk with no FKs should have the proper description
+ok 47 - col_is_fk with no FKs should have the proper diagnostics
+ok 48 - col_is_fk with no FKs should fail
+ok 49 - col_is_fk with no FKs should have the proper description
+ok 50 - col_is_fk with no FKs should have the proper diagnostics
+ok 51 - col_is_fk( schema, table, column[], description ) should pass
+ok 52 - col_is_fk( schema, table, column[], description ) should have the proper description
+ok 53 - col_is_fk( table, column[], description ) should pass
+ok 54 - col_is_fk( table, column[], description ) should have the proper description
+ok 55 - col_is_fk( table, column[] ) should pass
+ok 56 - col_is_fk( table, column[] ) should have the proper description
+ok 57 - col_isnt_fk( schema, table, column, description ) should fail
+ok 58 - col_isnt_fk( schema, table, column, description ) should have the proper description
+ok 59 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
+ok 60 - col_isnt_fk( table, column, description ) should fail
+ok 61 - col_isnt_fk( table, column, description ) should have the proper description
+ok 62 - col_isnt_fk( table, column, description ) should have the proper diagnostics
+ok 63 - col_isnt_fk( table, column ) should fail
+ok 64 - col_isnt_fk( table, column ) should have the proper description
+ok 65 - col_isnt_fk( table, column ) should have the proper diagnostics
+ok 66 - col_isnt_fk( schema, table, column, description ) should pass
+ok 67 - col_isnt_fk( schema, table, column, description ) should have the proper description
+ok 68 - col_isnt_fk( schema, table, column, description ) should have the proper diagnostics
+ok 69 - col_isnt_fk( table, column, description ) should pass
+ok 70 - col_isnt_fk( table, column, description ) should have the proper description
+ok 71 - col_isnt_fk( table, column, description ) should have the proper diagnostics
+ok 72 - multi-fk col_isnt_fk test should fail
+ok 73 - multi-fk col_isnt_fk test should have the proper description
+ok 74 - multi-fk col_isnt_fk test should have the proper diagnostics
+ok 75 - col_isnt_fk with no FKs should pass
+ok 76 - col_isnt_fk with no FKs should have the proper description
+ok 77 - col_isnt_fk with no FKs should have the proper diagnostics
+ok 78 - col_isnt_fk with no FKs should pass
+ok 79 - col_isnt_fk with no FKs should have the proper description
+ok 80 - col_isnt_fk with no FKs should have the proper diagnostics
+ok 81 - col_isnt_fk( schema, table, column[], description ) should fail
+ok 82 - col_isnt_fk( schema, table, column[], description ) should have the proper description
+ok 83 - col_isnt_fk( table, column[], description ) should fail
+ok 84 - col_isnt_fk( table, column[], description ) should have the proper description
+ok 85 - col_isnt_fk( table, column[] ) should fail
+ok 86 - col_isnt_fk( table, column[] ) should have the proper description
+ok 87 - full fk_ok array should pass
+ok 88 - full fk_ok array should have the proper description
+ok 89 - pg_my_temp_schema() should pass
+ok 90 - pg_my_temp_schema() should have the proper description
+ok 91 - multiple fk fk_ok desc should pass
+ok 92 - multiple fk fk_ok desc should have the proper description
+ok 93 - fk_ok array desc should pass
+ok 94 - fk_ok array desc should have the proper description
+ok 95 - fk_ok array noschema desc should pass
+ok 96 - fk_ok array noschema desc should have the proper description
+ok 97 - multiple fk fk_ok noschema desc should pass
+ok 98 - multiple fk fk_ok noschema desc should have the proper description
+ok 99 - fk_ok array noschema should pass
+ok 100 - fk_ok array noschema should have the proper description
+ok 101 - basic fk_ok should pass
+ok 102 - basic fk_ok should have the proper description
+ok 103 - basic fk_ok desc should pass
+ok 104 - basic fk_ok desc should have the proper description
+ok 105 - basic fk_ok noschema should pass
+ok 106 - basic fk_ok noschema should have the proper description
+ok 107 - basic fk_ok noschema desc should pass
+ok 108 - basic fk_ok noschema desc should have the proper description
+ok 109 - basic fk_ok noschema desc should have the proper diagnostics
+ok 110 - Test should pass
+ok 111 - fk_ok fail should fail
+ok 112 - fk_ok fail should have the proper description
+ok 113 - fk_ok fail should have the proper diagnostics
+ok 114 - fk_ok fail desc should fail
+ok 115 - fk_ok fail desc should have the proper description
+ok 116 - fk_ok fail desc should have the proper diagnostics
+ok 117 - fk_ok fail no schema should fail
+ok 118 - fk_ok fail no schema should have the proper description
+ok 119 - fk_ok fail no schema should have the proper diagnostics
+ok 120 - fk_ok fail no schema desc should fail
+ok 121 - fk_ok fail no schema desc should have the proper description
+ok 122 - fk_ok fail no schema desc should have the proper diagnostics
+ok 123 - fk_ok bad PK test should fail
+ok 124 - fk_ok bad PK test should have the proper description
+ok 125 - fk_ok bad PK test should have the proper diagnostics
+ok 126 - double fk schema test should pass
+ok 127 - double fk schema test should have the proper description
+ok 128 - double fk schema test should have the proper diagnostics
+ok 129 - double fk test should pass
+ok 130 - double fk test should have the proper description
+ok 131 - double fk test should have the proper diagnostics
+ok 132 - double fk and col schema test should pass
+ok 133 - double fk and col schema test should have the proper description
+ok 134 - double fk and col schema test should have the proper diagnostics
+ok 135 - missing fk test should fail
+ok 136 - missing fk test should have the proper description
+ok 137 - missing fk test should have the proper diagnostics
+ok 138 - bad FK column test should fail
+ok 139 - bad FK column test should have the proper description
+ok 140 - bad FK column test should have the proper diagnostics

--- a/test/expected/pktap.out
+++ b/test/expected/pktap.out
@@ -1,5 +1,5 @@
 \unset ECHO
-1..96
+1..102
 ok 1 - has_pk( schema, table, description ) should pass
 ok 2 - has_pk( schema, table, description ) should have the proper description
 ok 3 - has_pk( schema, table, description ) should have the proper diagnostics
@@ -30,69 +30,75 @@ ok 27 - has_pk( table, description ) fail should have the proper diagnostics
 ok 28 - hasnt_pk( schema, table, description ) should fail
 ok 29 - hasnt_pk( schema, table, description ) should have the proper description
 ok 30 - hasnt_pk( schema, table, description ) should have the proper diagnostics
-ok 31 - hasnt_pk( table, description ) should fail
-ok 32 - hasnt_pk( table, description ) should have the proper description
-ok 33 - hasnt_pk( table, description ) should have the proper diagnostics
-ok 34 - hasnt_pk( table ) should fail
-ok 35 - hasnt_pk( table ) should have the proper description
-ok 36 - hasnt_pk( table ) should have the proper diagnostics
-ok 37 - hasnt_pk( schema, table, description ) pass should pass
-ok 38 - hasnt_pk( schema, table, description ) pass should have the proper description
-ok 39 - hasnt_pk( schema, table, description ) pass should have the proper diagnostics
-ok 40 - hasnt_pk( table, description ) pass should pass
-ok 41 - hasnt_pk( table, description ) pass should have the proper description
-ok 42 - hasnt_pk( table, description ) pass should have the proper diagnostics
-ok 43 - col_is_pk( schema, table, column, description ) should pass
-ok 44 - col_is_pk( schema, table, column, description ) should have the proper description
-ok 45 - col_is_pk( schema, table, column, description ) should have the proper diagnostics
-ok 46 - col_is_pk( schema, table, column ) should pass
-ok 47 - col_is_pk( schema, table, column ) should have the proper description
-ok 48 - col_is_pk( schema, table, column ) should have the proper diagnostics
-ok 49 - col_is_pk( table, column, description ) should pass
-ok 50 - col_is_pk( table, column, description ) should have the proper description
-ok 51 - col_is_pk( table, column, description ) should have the proper diagnostics
-ok 52 - col_is_pk( table, column ) should pass
-ok 53 - col_is_pk( table, column ) should have the proper description
-ok 54 - col_is_pk( table, column ) should have the proper diagnostics
-ok 55 - col_is_pk( schema, table, column, description ) fail should fail
-ok 56 - col_is_pk( schema, table, column, description ) fail should have the proper description
-ok 57 - col_is_pk( schema, table, column, description ) fail should have the proper diagnostics
-ok 58 - col_is_pk( table, column, description ) fail should fail
-ok 59 - col_is_pk( table, column, description ) fail should have the proper description
-ok 60 - col_is_pk( table, column, description ) fail should have the proper diagnostics
-ok 61 - col_is_pk( schema, table, column[], description ) should pass
-ok 62 - col_is_pk( schema, table, column[], description ) should have the proper description
-ok 63 - col_is_pk( schema, table, column[], description ) should have the proper diagnostics
-ok 64 - col_is_pk( schema, table, column[] ) should pass
-ok 65 - col_is_pk( schema, table, column[] ) should have the proper description
-ok 66 - col_is_pk( schema, table, column[] ) should have the proper diagnostics
-ok 67 - col_is_pk( table, column[], description ) should pass
-ok 68 - col_is_pk( table, column[], description ) should have the proper description
-ok 69 - col_is_pk( table, column[], description ) should have the proper diagnostics
-ok 70 - col_is_pk( table, column[] ) should pass
-ok 71 - col_is_pk( table, column[] ) should have the proper description
-ok 72 - col_is_pk( table, column[] ) should have the proper diagnostics
-ok 73 - col_isnt_pk( schema, table, column, description ) should fail
-ok 74 - col_isnt_pk( schema, table, column, description ) should have the proper description
-ok 75 - col_isnt_pk( schema, table, column, description ) should have the proper diagnostics
-ok 76 - col_isnt_pk( table, column, description ) should fail
-ok 77 - col_isnt_pk( table, column, description ) should have the proper description
-ok 78 - col_isnt_pk( table, column, description ) should have the proper diagnostics
-ok 79 - col_isnt_pk( table, column ) should fail
-ok 80 - col_isnt_pk( table, column ) should have the proper description
-ok 81 - col_isnt_pk( table, column ) should have the proper diagnostics
-ok 82 - col_isnt_pk( schema, table, column, description ) pass should pass
-ok 83 - col_isnt_pk( schema, table, column, description ) pass should have the proper description
-ok 84 - col_isnt_pk( schema, table, column, description ) pass should have the proper diagnostics
-ok 85 - col_isnt_pk( table, column, description ) pass should pass
-ok 86 - col_isnt_pk( table, column, description ) pass should have the proper description
-ok 87 - col_isnt_pk( table, column, description ) pass should have the proper diagnostics
-ok 88 - col_isnt_pk( schema, table, column[], description ) should pass
-ok 89 - col_isnt_pk( schema, table, column[], description ) should have the proper description
-ok 90 - col_isnt_pk( schema, table, column[], description ) should have the proper diagnostics
-ok 91 - col_isnt_pk( table, column[], description ) should pass
-ok 92 - col_isnt_pk( table, column[], description ) should have the proper description
-ok 93 - col_isnt_pk( table, column[], description ) should have the proper diagnostics
-ok 94 - col_isnt_pk( table, column[] ) should pass
-ok 95 - col_isnt_pk( table, column[] ) should have the proper description
-ok 96 - col_isnt_pk( table, column[] ) should have the proper diagnostics
+ok 31 - hasnt_pk( schema, table ) should fail
+ok 32 - hasnt_pk( schema, table ) should have the proper description
+ok 33 - hasnt_pk( schema, table ) should have the proper diagnostics
+ok 34 - hasnt_pk( table, description ) should fail
+ok 35 - hasnt_pk( table, description ) should have the proper description
+ok 36 - hasnt_pk( table, description ) should have the proper diagnostics
+ok 37 - hasnt_pk( table ) should fail
+ok 38 - hasnt_pk( table ) should have the proper description
+ok 39 - hasnt_pk( table ) should have the proper diagnostics
+ok 40 - hasnt_pk( schema, table, description ) pass should pass
+ok 41 - hasnt_pk( schema, table, description ) pass should have the proper description
+ok 42 - hasnt_pk( schema, table, description ) pass should have the proper diagnostics
+ok 43 - hasnt_pk( schema, table ) pass should pass
+ok 44 - hasnt_pk( schema, table ) pass should have the proper description
+ok 45 - hasnt_pk( schema, table ) pass should have the proper diagnostics
+ok 46 - hasnt_pk( table, description ) pass should pass
+ok 47 - hasnt_pk( table, description ) pass should have the proper description
+ok 48 - hasnt_pk( table, description ) pass should have the proper diagnostics
+ok 49 - col_is_pk( schema, table, column, description ) should pass
+ok 50 - col_is_pk( schema, table, column, description ) should have the proper description
+ok 51 - col_is_pk( schema, table, column, description ) should have the proper diagnostics
+ok 52 - col_is_pk( schema, table, column ) should pass
+ok 53 - col_is_pk( schema, table, column ) should have the proper description
+ok 54 - col_is_pk( schema, table, column ) should have the proper diagnostics
+ok 55 - col_is_pk( table, column, description ) should pass
+ok 56 - col_is_pk( table, column, description ) should have the proper description
+ok 57 - col_is_pk( table, column, description ) should have the proper diagnostics
+ok 58 - col_is_pk( table, column ) should pass
+ok 59 - col_is_pk( table, column ) should have the proper description
+ok 60 - col_is_pk( table, column ) should have the proper diagnostics
+ok 61 - col_is_pk( schema, table, column, description ) fail should fail
+ok 62 - col_is_pk( schema, table, column, description ) fail should have the proper description
+ok 63 - col_is_pk( schema, table, column, description ) fail should have the proper diagnostics
+ok 64 - col_is_pk( table, column, description ) fail should fail
+ok 65 - col_is_pk( table, column, description ) fail should have the proper description
+ok 66 - col_is_pk( table, column, description ) fail should have the proper diagnostics
+ok 67 - col_is_pk( schema, table, column[], description ) should pass
+ok 68 - col_is_pk( schema, table, column[], description ) should have the proper description
+ok 69 - col_is_pk( schema, table, column[], description ) should have the proper diagnostics
+ok 70 - col_is_pk( schema, table, column[] ) should pass
+ok 71 - col_is_pk( schema, table, column[] ) should have the proper description
+ok 72 - col_is_pk( schema, table, column[] ) should have the proper diagnostics
+ok 73 - col_is_pk( table, column[], description ) should pass
+ok 74 - col_is_pk( table, column[], description ) should have the proper description
+ok 75 - col_is_pk( table, column[], description ) should have the proper diagnostics
+ok 76 - col_is_pk( table, column[] ) should pass
+ok 77 - col_is_pk( table, column[] ) should have the proper description
+ok 78 - col_is_pk( table, column[] ) should have the proper diagnostics
+ok 79 - col_isnt_pk( schema, table, column, description ) should fail
+ok 80 - col_isnt_pk( schema, table, column, description ) should have the proper description
+ok 81 - col_isnt_pk( schema, table, column, description ) should have the proper diagnostics
+ok 82 - col_isnt_pk( table, column, description ) should fail
+ok 83 - col_isnt_pk( table, column, description ) should have the proper description
+ok 84 - col_isnt_pk( table, column, description ) should have the proper diagnostics
+ok 85 - col_isnt_pk( table, column ) should fail
+ok 86 - col_isnt_pk( table, column ) should have the proper description
+ok 87 - col_isnt_pk( table, column ) should have the proper diagnostics
+ok 88 - col_isnt_pk( schema, table, column, description ) pass should pass
+ok 89 - col_isnt_pk( schema, table, column, description ) pass should have the proper description
+ok 90 - col_isnt_pk( schema, table, column, description ) pass should have the proper diagnostics
+ok 91 - col_isnt_pk( table, column, description ) pass should pass
+ok 92 - col_isnt_pk( table, column, description ) pass should have the proper description
+ok 93 - col_isnt_pk( table, column, description ) pass should have the proper diagnostics
+ok 94 - col_isnt_pk( schema, table, column[], description ) should pass
+ok 95 - col_isnt_pk( schema, table, column[], description ) should have the proper description
+ok 96 - col_isnt_pk( schema, table, column[], description ) should have the proper diagnostics
+ok 97 - col_isnt_pk( table, column[], description ) should pass
+ok 98 - col_isnt_pk( table, column[], description ) should have the proper description
+ok 99 - col_isnt_pk( table, column[], description ) should have the proper diagnostics
+ok 100 - col_isnt_pk( table, column[] ) should pass
+ok 101 - col_isnt_pk( table, column[] ) should have the proper description
+ok 102 - col_isnt_pk( table, column[] ) should have the proper diagnostics

--- a/test/expected/unique.out
+++ b/test/expected/unique.out
@@ -1,56 +1,80 @@
 \unset ECHO
-1..54
+1..78
 ok 1 - has_unique( schema, table, description ) should pass
 ok 2 - has_unique( schema, table, description ) should have the proper description
 ok 3 - has_unique( schema, table, description ) should have the proper diagnostics
-ok 4 - has_unique( table, description ) should pass
-ok 5 - has_unique( table, description ) should have the proper description
-ok 6 - has_unique( table, description ) should have the proper diagnostics
-ok 7 - has_unique( table ) should pass
-ok 8 - has_unique( table ) should have the proper description
-ok 9 - has_unique( table ) should have the proper diagnostics
-ok 10 - has_unique( schema, table, description ) fail should fail
-ok 11 - has_unique( schema, table, description ) fail should have the proper description
-ok 12 - has_unique( schema, table, description ) fail should have the proper diagnostics
-ok 13 - has_unique( table, description ) fail should fail
-ok 14 - has_unique( table, description ) fail should have the proper description
-ok 15 - has_unique( table, description ) fail should have the proper diagnostics
-ok 16 - col_is_unique( schema, table, column, description ) should pass
-ok 17 - col_is_unique( schema, table, column, description ) should have the proper description
-ok 18 - col_is_unique( schema, table, column, description ) should have the proper diagnostics
-ok 19 - col_is_unique( schema, table, columns, description ) should pass
-ok 20 - col_is_unique( schema, table, columns, description ) should have the proper description
-ok 21 - col_is_unique( schema, table, columns, description ) should have the proper diagnostics
-ok 22 - col_is_unique( table, column, description ) should pass
-ok 23 - col_is_unique( table, column, description ) should have the proper description
-ok 24 - col_is_unique( table, column, description ) should have the proper diagnostics
-ok 25 - col_is_unique( table, columns, description ) should pass
-ok 26 - col_is_unique( table, columns, description ) should have the proper description
-ok 27 - col_is_unique( table, columns, description ) should have the proper diagnostics
-ok 28 - col_is_unique( schema, table, column ) should pass
-ok 29 - col_is_unique( schema, table, column ) should have the proper description
-ok 30 - col_is_unique( schema, table, column ) should have the proper diagnostics
-ok 31 - col_is_unique( schema, table, columns ) should pass
-ok 32 - col_is_unique( schema, table, columns ) should have the proper description
-ok 33 - col_is_unique( schema, table, columns ) should have the proper diagnostics
-ok 34 - col_is_unique( table, column ) should pass
-ok 35 - col_is_unique( table, column ) should have the proper description
-ok 36 - col_is_unique( table, column ) should have the proper diagnostics
-ok 37 - col_is_unique( table, columns ) should pass
-ok 38 - col_is_unique( table, columns ) should have the proper description
-ok 39 - col_is_unique( table, columns ) should have the proper diagnostics
-ok 40 - col_is_unique( schema, table, column, description ) fail should fail
-ok 41 - col_is_unique( schema, table, column, description ) fail should have the proper description
-ok 42 - col_is_unique( schema, table, column, description ) fail should have the proper diagnostics
-ok 43 - col_is_unique( table, column, description ) fail should fail
-ok 44 - col_is_unique( table, column, description ) fail should have the proper description
-ok 45 - col_is_unique( table, column, description ) fail should have the proper diagnostics
-ok 46 - col_is_unique( schema, table, column[], description ) should pass
-ok 47 - col_is_unique( schema, table, column[], description ) should have the proper description
-ok 48 - col_is_unique( schema, table, column[], description ) should have the proper diagnostics
-ok 49 - col_is_unique( table, column[], description ) should pass
-ok 50 - col_is_unique( table, column[], description ) should have the proper description
-ok 51 - col_is_unique( table, column[], description ) should have the proper diagnostics
-ok 52 - col_is_unique( table, column[] ) should pass
-ok 53 - col_is_unique( table, column[] ) should have the proper description
-ok 54 - col_is_unique( table, column[] ) should have the proper diagnostics
+ok 4 - has_unique( schema, table ) should pass
+ok 5 - has_unique( schema, table ) should have the proper description
+ok 6 - has_unique( schema, table ) should have the proper diagnostics
+ok 7 - has_unique( table, description ) should pass
+ok 8 - has_unique( table, description ) should have the proper description
+ok 9 - has_unique( table, description ) should have the proper diagnostics
+ok 10 - has_unique( table ) should pass
+ok 11 - has_unique( table ) should have the proper description
+ok 12 - has_unique( table ) should have the proper diagnostics
+ok 13 - has_unique( schema, table, description ) fail should fail
+ok 14 - has_unique( schema, table, description ) fail should have the proper description
+ok 15 - has_unique( schema, table, description ) fail should have the proper diagnostics
+ok 16 - has_unique( table, description ) fail should fail
+ok 17 - has_unique( table, description ) fail should have the proper description
+ok 18 - has_unique( table, description ) fail should have the proper diagnostics
+ok 19 - hasnt_unique( schema, table, description ) should fail
+ok 20 - hasnt_unique( schema, table, description ) should have the proper description
+ok 21 - hasnt_unique( schema, table, description ) should have the proper diagnostics
+ok 22 - hasnt_unique( schema, table ) should fail
+ok 23 - hasnt_unique( schema, table ) should have the proper description
+ok 24 - hasnt_unique( schema, table ) should have the proper diagnostics
+ok 25 - hasnt_unique( table, description ) should fail
+ok 26 - hasnt_unique( table, description ) should have the proper description
+ok 27 - hasnt_unique( table, description ) should have the proper diagnostics
+ok 28 - hasnt_unique( table ) should fail
+ok 29 - hasnt_unique( table ) should have the proper description
+ok 30 - hasnt_unique( table ) should have the proper diagnostics
+ok 31 - hasnt_unique( schema, table, description ) pass should pass
+ok 32 - hasnt_unique( schema, table, description ) pass should have the proper description
+ok 33 - hasnt_unique( schema, table, description ) pass should have the proper diagnostics
+ok 34 - hasnt_unique( schema, table ) pass should pass
+ok 35 - hasnt_unique( schema, table ) pass should have the proper description
+ok 36 - hasnt_unique( schema, table ) pass should have the proper diagnostics
+ok 37 - hasnt_unique( table, description ) pass should pass
+ok 38 - hasnt_unique( table, description ) pass should have the proper description
+ok 39 - hasnt_unique( table, description ) pass should have the proper diagnostics
+ok 40 - col_is_unique( schema, table, column, description ) should pass
+ok 41 - col_is_unique( schema, table, column, description ) should have the proper description
+ok 42 - col_is_unique( schema, table, column, description ) should have the proper diagnostics
+ok 43 - col_is_unique( schema, table, columns, description ) should pass
+ok 44 - col_is_unique( schema, table, columns, description ) should have the proper description
+ok 45 - col_is_unique( schema, table, columns, description ) should have the proper diagnostics
+ok 46 - col_is_unique( table, column, description ) should pass
+ok 47 - col_is_unique( table, column, description ) should have the proper description
+ok 48 - col_is_unique( table, column, description ) should have the proper diagnostics
+ok 49 - col_is_unique( table, columns, description ) should pass
+ok 50 - col_is_unique( table, columns, description ) should have the proper description
+ok 51 - col_is_unique( table, columns, description ) should have the proper diagnostics
+ok 52 - col_is_unique( schema, table, column ) should pass
+ok 53 - col_is_unique( schema, table, column ) should have the proper description
+ok 54 - col_is_unique( schema, table, column ) should have the proper diagnostics
+ok 55 - col_is_unique( schema, table, columns ) should pass
+ok 56 - col_is_unique( schema, table, columns ) should have the proper description
+ok 57 - col_is_unique( schema, table, columns ) should have the proper diagnostics
+ok 58 - col_is_unique( table, column ) should pass
+ok 59 - col_is_unique( table, column ) should have the proper description
+ok 60 - col_is_unique( table, column ) should have the proper diagnostics
+ok 61 - col_is_unique( table, columns ) should pass
+ok 62 - col_is_unique( table, columns ) should have the proper description
+ok 63 - col_is_unique( table, columns ) should have the proper diagnostics
+ok 64 - col_is_unique( schema, table, column, description ) fail should fail
+ok 65 - col_is_unique( schema, table, column, description ) fail should have the proper description
+ok 66 - col_is_unique( schema, table, column, description ) fail should have the proper diagnostics
+ok 67 - col_is_unique( table, column, description ) fail should fail
+ok 68 - col_is_unique( table, column, description ) fail should have the proper description
+ok 69 - col_is_unique( table, column, description ) fail should have the proper diagnostics
+ok 70 - col_is_unique( schema, table, column[], description ) should pass
+ok 71 - col_is_unique( schema, table, column[], description ) should have the proper description
+ok 72 - col_is_unique( schema, table, column[], description ) should have the proper diagnostics
+ok 73 - col_is_unique( table, column[], description ) should pass
+ok 74 - col_is_unique( table, column[], description ) should have the proper description
+ok 75 - col_is_unique( table, column[], description ) should have the proper diagnostics
+ok 76 - col_is_unique( table, column[] ) should pass
+ok 77 - col_is_unique( table, column[] ) should have the proper description
+ok 78 - col_is_unique( table, column[] ) should have the proper diagnostics

--- a/test/sql/check.sql
+++ b/test/sql/check.sql
@@ -1,7 +1,7 @@
 \unset ECHO
 \i test/setup.sql
 
-SELECT plan(48);
+SELECT plan(72);
 
 -- This will be rolled back. :-)
 SET client_min_messages = warning;
@@ -22,6 +22,14 @@ SELECT * FROM check_test(
     true,
     'has_check( schema, table, desc )',
     'public.sometab should have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    has_check( 'public', 'sometab'::name ),
+    true,
+    'has_check( schema, table )',
+    'Table public.sometab should have a check constraint',
     ''
 );
 
@@ -54,6 +62,65 @@ SELECT * FROM check_test(
     false,
     'has_check( table, desc ) fail',
     'pg_class should have a check constraint',
+    ''
+);
+
+/****************************************************************************/
+-- Test hasnt_check().
+
+SELECT * FROM check_test(
+    hasnt_check( 'public', 'sometab', 'public.sometab should not have a check constraint' ),
+    false,
+    'hasnt_check( schema, table, description )',
+    'public.sometab should not have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_check( 'public', 'sometab'::name ),
+    false,
+    'hasnt_check( schema, table )',
+    'Table public.sometab should not have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_check( 'sometab', 'sometab should not have a check constraint' ),
+    false,
+    'hasnt_check( table, description )',
+    'sometab should not have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_check( 'sometab' ),
+    false,
+    'hasnt_check( table )',
+    'Table sometab should not have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_check( 'pg_catalog', 'pg_class', 'pg_catalog.pg_class should not have a check constraint' ),
+    true,
+    'hasnt_check( schema, table, description ) pass',
+    'pg_catalog.pg_class should not have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_check( 'pg_catalog', 'pg_class'::name ),
+    true,
+    'hasnt_check( schema, table ) pass',
+    'Table pg_catalog.pg_class should not have a check constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_check( 'pg_class', 'pg_class should not have a check constraint' ),
+    true,
+    'hasnt_check( table, description ) pass',
+    'pg_class should not have a check constraint',
     ''
 );
 

--- a/test/sql/fktap.sql
+++ b/test/sql/fktap.sql
@@ -1,7 +1,7 @@
 \unset ECHO
 \i test/setup.sql
 
-SELECT plan(134);
+SELECT plan(140);
 --SELECT * from no_plan();
 
 -- These will be rolled back. :-)
@@ -78,6 +78,13 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
+    has_fk( 'public', 'fk'::name ),
+    true,
+    'has_fk( schema, table )',
+    'Table public.fk should have a foreign key constraint'
+);
+
+SELECT * FROM check_test(
     has_fk( 'fk', 'fk should have an fk' ),
     'true',
     'has_fk( table, description )',
@@ -129,6 +136,13 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
+    hasnt_fk( 'public', 'fk'::name ),
+    false,
+    'hasnt_fk( schema, table )',
+    'Table public.fk should not have a foreign key constraint'
+);
+
+SELECT * FROM check_test(
     hasnt_fk( 'fk', 'fk should not have an fk' ),
     'false',
     'hasnt_fk( table, description )',
@@ -147,6 +161,13 @@ SELECT * FROM check_test(
     true,
     'hasnt_fk( schema, table, description ) pass',
     'pg_catalog.pg_class should not have an fk'
+);
+
+SELECT * FROM check_test(
+    hasnt_fk( 'pg_catalog', 'pg_class'::name ),
+    true,
+    'hasnt_fk( schema, table ) pass',
+    'Table pg_catalog.pg_class should not have a foreign key constraint'
 );
 
 SELECT * FROM check_test(

--- a/test/sql/pktap.sql
+++ b/test/sql/pktap.sql
@@ -2,7 +2,7 @@
 \i test/setup.sql
 -- \i sql/pgtap.sql
 
-SELECT plan(96);
+SELECT plan(102);
 --SELECT * FROM no_plan();
 
 -- This will be rolled back. :-)
@@ -114,6 +114,14 @@ SELECT * FROM check_test(
 );
 
 SELECT * FROM check_test(
+    hasnt_pk( 'public', 'sometab'::name ),
+    false,
+    'hasnt_pk( schema, table )',
+    'Table public.sometab should not have a primary key',
+    ''
+);
+
+SELECT * FROM check_test(
     hasnt_pk( 'sometab', 'sometab should not have a pk' ),
     false,
     'hasnt_pk( table, description )',
@@ -134,6 +142,14 @@ SELECT * FROM check_test(
     true,
     'hasnt_pk( schema, table, description ) pass',
     'public.pkless should not have a pk',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_pk( 'public', 'pkless'::name ),
+    true,
+    'hasnt_pk( schema, table ) pass',
+    'Table public.pkless should not have a primary key',
     ''
 );
 

--- a/test/sql/unique.sql
+++ b/test/sql/unique.sql
@@ -1,7 +1,7 @@
 \unset ECHO
 \i test/setup.sql
 
-SELECT plan(18*3);
+SELECT plan(78);
 
 -- This will be rolled back. :-)
 SET client_min_messages = warning;
@@ -26,6 +26,14 @@ SELECT * FROM check_test(
     true,
     'has_unique( schema, table, description )',
     'public.sometab should have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    has_unique( 'public', 'sometab'::name ),
+    true,
+    'has_unique( schema, table )',
+    'Table public.sometab should have a unique constraint',
     ''
 );
 
@@ -58,6 +66,65 @@ SELECT * FROM check_test(
     false,
     'has_unique( table, description ) fail',
     'uniqueless should have a unique constraint',
+    ''
+);
+
+/****************************************************************************/
+-- Test hasnt_unique().
+
+SELECT * FROM check_test(
+    hasnt_unique( 'public', 'sometab', 'public.sometab should not have a unique constraint' ),
+    false,
+    'hasnt_unique( schema, table, description )',
+    'public.sometab should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_unique( 'public', 'sometab'::name ),
+    false,
+    'hasnt_unique( schema, table )',
+    'Table public.sometab should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_unique( 'sometab', 'sometab should not have a unique constraint' ),
+    false,
+    'hasnt_unique( table, description )',
+    'sometab should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_unique( 'sometab' ),
+    false,
+    'hasnt_unique( table )',
+    'Table sometab should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_unique( 'public', 'uniqueless', 'public.uniqueless should not have a unique constraint' ),
+    true,
+    'hasnt_unique( schema, table, description ) pass',
+    'public.uniqueless should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_unique( 'public', 'uniqueless'::name ),
+    true,
+    'hasnt_unique( schema, table ) pass',
+    'Table public.uniqueless should not have a unique constraint',
+    ''
+);
+
+SELECT * FROM check_test(
+    hasnt_unique( 'uniqueless', 'uniqueless should not have a unique constraint' ),
+    true,
+    'hasnt_unique( table, description ) pass',
+    'uniqueless should not have a unique constraint',
     ''
 );
 


### PR DESCRIPTION
Closes #363 [2/3]

As discussed this is the first part of the PR split -> implementation symmetry, part 2.

All 4 now follow:
```sql
-- has{nt}_X( schema, table, description ) -- ( NAME, NAME, TEXT )
-- has{nt}_X( schema, table )              -- ( NAME, NAME )
-- has{nt}_X( table, description )         -- ( NAME, TEXT )
-- has{nt}_X( table )                      -- ( NAME )
```
