### PR TITLE
Add extension_requires() and extension_requires_are()

### DIFF
--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -2925,7 +2925,7 @@ SELECT extensions_are( :extensions );
 
 This function tests all of the extensions that should be present. If `:schema`
 is specified, it will test only for extensions associated the named schema (via
-the `schema` parameter in the extension's control file, ov the `WITH SCHEMA`
+the `schema` parameter in the extension's control file, or the `WITH SCHEMA`
 clause of the
 [CREATE EXTENSION](https://www.postgresql.org/docs/current/static/extend-extensions.html)
 statement). Otherwise it will check for all extension in the database,

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -2968,13 +2968,11 @@ SELECT extension_requires_are( :extension, :requires );
 `:description`
 : A short description of the test.
 
-This function tests the exact set of extensions that `:extension` requires.
-It checks what PostgreSQL recorded as a dependency when `:extension` was
-created (via `pg_depend`), not `:extension`'s control file's `requires`
-field, which can differ if the control file was edited after the extension
-was installed. If `:extension` itself does not exist, the test fails the
-same way `has_extension()` does. If the description is omitted, a
-generally useful default description will be generated. Example:
+This function tests the exact set of extensions that `:extension` requires,
+based on what PostgreSQL recorded when `:extension` was created. If
+`:extension` itself does not exist, the test fails the same way
+`has_extension()` does. If the description is omitted, a generally useful
+default description will be generated. Example:
 
 ```sql
 SELECT extension_requires_are( 'earthdistance', ARRAY[ 'cube' ] );
@@ -4765,12 +4763,11 @@ SELECT extension_requires( :extension, :required_extension );
 `:description`
 : A short description of the test.
 
-This function tests whether `:extension` requires `:required_extension` (as
-recorded by PostgreSQL when `:extension` was created, not merely what
-`:extension`'s control file on disk declares). If `:extension` itself does
-not exist, the test fails the same way `has_extension()` does. If the test
-description is omitted, it will be set to "Extension `:extension` should
-require extension `:required_extension`". Example:
+This function tests whether `:extension` requires `:required_extension`, as
+recorded by PostgreSQL when `:extension` was created. If `:extension`
+itself does not exist, the test fails the same way `has_extension()` does.
+If the test description is omitted, it will be set to "Extension
+`:extension` should require extension `:required_extension`". Example:
 
 ```sql
 SELECT extension_requires('earthdistance', 'cube');

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -2978,15 +2978,6 @@ default description will be generated. Example:
 SELECT extension_requires_are( 'earthdistance', ARRAY[ 'cube' ] );
 ```
 
-In the event of a failure, you'll see diagnostics listing the extra and/or
-missing required extensions, like so:
-
-    # Failed test 91: "Extension earthdistance should require the correct extensions"
-    #     Extra required extensions:
-    #         cube
-    #     Missing required extensions:
-    #         citext
-
 To Have or Have Not
 -------------------
 

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -2950,6 +2950,45 @@ missing extensions, like so:
     #         citext
     #         isn
 
+### `extension_requires_are()` ###
+
+```sql
+SELECT extension_requires_are( :extension, :requires, :description );
+SELECT extension_requires_are( :extension, :requires );
+```
+
+**Parameters**
+
+`:extension`
+: Name of an extension.
+
+`:requires`
+: An array of the names of the extensions `:extension` should require.
+
+`:description`
+: A short description of the test.
+
+This function tests the exact set of extensions that `:extension` requires.
+It checks what PostgreSQL recorded as a dependency when `:extension` was
+created (via `pg_depend`), not `:extension`'s control file's `requires`
+field, which can differ if the control file was edited after the extension
+was installed. If `:extension` itself does not exist, the test fails the
+same way `has_extension()` does. If the description is omitted, a
+generally useful default description will be generated. Example:
+
+```sql
+SELECT extension_requires_are( 'earthdistance', ARRAY[ 'cube' ] );
+```
+
+In the event of a failure, you'll see diagnostics listing the extra and/or
+missing required extensions, like so:
+
+    # Failed test 91: "Extension earthdistance should require the correct extensions"
+    #     Extra required extensions:
+    #         cube
+    #     Missing required extensions:
+    #         citext
+
 To Have or Have Not
 -------------------
 
@@ -4707,6 +4746,35 @@ SELECT hasnt_extension( :extension );
 
 This function is the inverse of `has_extension()`. The test passes if the
 specified extension does *not* exist.
+
+### `extension_requires()` ###
+
+```sql
+SELECT extension_requires( :extension, :required_extension, :description );
+SELECT extension_requires( :extension, :required_extension );
+```
+
+**Parameters**
+
+`:extension`
+: Name of an extension.
+
+`:required_extension`
+: Name of the extension that `:extension` should require.
+
+`:description`
+: A short description of the test.
+
+This function tests whether `:extension` requires `:required_extension` (as
+recorded by PostgreSQL when `:extension` was created, not merely what
+`:extension`'s control file on disk declares). If `:extension` itself does
+not exist, the test fails the same way `has_extension()` does. If the test
+description is omitted, it will be set to "Extension `:extension` should
+require extension `:required_extension`". Example:
+
+```sql
+SELECT extension_requires('earthdistance', 'cube');
+```
 
 Table For One
 -------------

--- a/doc/pgtap.md
+++ b/doc/pgtap.md
@@ -2928,7 +2928,7 @@ is specified, it will test only for extensions associated the named schema (via
 the `schema` parameter in the extension's control file, or the `WITH SCHEMA`
 clause of the
 [CREATE EXTENSION](https://www.postgresql.org/docs/current/static/extend-extensions.html)
-statement). Otherwise it will check for all extension in the database,
+statement). Otherwise it will check for all extensions in the database,
 including pgTAP itself. If the description is omitted, a generally useful
 default description will be generated. Example:
 

--- a/sql/pgtap.sql.in
+++ b/sql/pgtap.sql.in
@@ -10339,6 +10339,70 @@ RETURNS TEXT AS $$
         'Extension ' || quote_ident($1) || ' should not exist' );
 $$ LANGUAGE SQL;
 
+-- Get the extensions a given extension requires
+CREATE OR REPLACE FUNCTION _extension_requires( NAME )
+RETURNS SETOF NAME AS $$
+    SELECT req.extname
+      FROM pg_catalog.pg_depend d
+      JOIN pg_catalog.pg_extension ext ON d.classid    = 'pg_catalog.pg_extension'::regclass
+                                       AND d.objid      = ext.oid
+      JOIN pg_catalog.pg_extension req ON d.refclassid = 'pg_catalog.pg_extension'::regclass
+                                       AND d.refobjid   = req.oid
+     WHERE ext.extname = $1
+       AND d.deptype    = 'n'
+$$ LANGUAGE SQL;
+
+-- extension_requires_are( extension, requires, description )
+CREATE OR REPLACE FUNCTION extension_requires_are( NAME, NAME[], TEXT )
+RETURNS TEXT AS $$
+BEGIN
+    IF NOT _ext_exists($1) THEN
+        RETURN fail($3) || E'\n' || diag(
+            '    Extension ' || quote_ident($1) || ' does not exist'
+        );
+    END IF;
+
+    RETURN _are(
+        'required extensions',
+        ARRAY( SELECT _extension_requires($1) EXCEPT SELECT unnest($2) ),
+        ARRAY( SELECT unnest($2) EXCEPT SELECT _extension_requires($1) ),
+        $3
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- extension_requires_are( extension, requires )
+CREATE OR REPLACE FUNCTION extension_requires_are( NAME, NAME[] )
+RETURNS TEXT AS $$
+    SELECT extension_requires_are(
+        $1, $2,
+        'Extension ' || quote_ident($1) || ' should require the correct extensions'
+    );
+$$ LANGUAGE SQL;
+
+-- extension_requires( extension, required_extension, description )
+CREATE OR REPLACE FUNCTION extension_requires( NAME, NAME, TEXT )
+RETURNS TEXT AS $$
+BEGIN
+    IF NOT _ext_exists($1) THEN
+        RETURN fail($3) || E'\n' || diag(
+            '    Extension ' || quote_ident($1) || ' does not exist'
+        );
+    END IF;
+
+    RETURN ok( $2 = ANY( ARRAY( SELECT _extension_requires($1) ) ), $3 );
+END;
+$$ LANGUAGE plpgsql;
+
+-- extension_requires( extension, required_extension )
+CREATE OR REPLACE FUNCTION extension_requires( NAME, NAME )
+RETURNS TEXT AS $$
+    SELECT extension_requires(
+        $1, $2,
+        'Extension ' || quote_ident($1) || ' should require extension ' || quote_ident($2)
+    );
+$$ LANGUAGE SQL;
+
 -- is_partitioned( schema, table, description )
 CREATE OR REPLACE FUNCTION is_partitioned ( NAME, NAME, TEXT )
 RETURNS TEXT AS $$


### PR DESCRIPTION
Proposes two new assertion functions for verifying an extension's declared dependencies (its control file `requires`), analogous to the existing `has_extension()` / `extensions_are()` pair:

- `extension_requires( extension, required_extension[, description] )` — asserts that `extension` requires `required_extension`.
- `extension_requires_are( extension, requires[][, description] )` — asserts the exact set of extensions that `extension` requires, with Extra/Missing diagnostics like `extensions_are()`.

Both are backed by a new internal helper, `_extension_requires(name)`, which reads the requirement from `pg_depend`/`pg_extension` (the runtime record of what actually got pulled in via `CREATE EXTENSION ... REQUIRES`), not `pg_available_extensions`. Both guard on the target extension not being installed, failing the same way `has_extension()` does rather than reporting a confusing all-missing diff.

## Test plan

Manually verified against `earthdistance` (which requires `cube`):
- [x] `extension_requires('earthdistance', 'cube')` passes
- [x] `extension_requires('earthdistance', 'citext')` fails
- [x] `extension_requires_are('earthdistance', ARRAY['cube'])` passes
- [x] `extension_requires_are('earthdistance', ARRAY['citext'])` fails with Extra/Missing diagnostics
- [x] Both fail like `has_extension()` when the base extension doesn't exist
- [ ] No automated test coverage yet — pending API sign-off
